### PR TITLE
Fixed to prevent failure with systems that dont support window scaling.

### DIFF
--- a/src/test/java/org/ice4j/pseudotcp/PseudoTcpTestRecvWindow.java
+++ b/src/test/java/org/ice4j/pseudotcp/PseudoTcpTestRecvWindow.java
@@ -390,8 +390,15 @@ public class PseudoTcpTestRecvWindow extends PseudoTcpTestBase
         test.setOptNagling(false);
         test.setOptAckDelay(0);
         int wndSize = 300000;
+        // if window scaling is not supported by either local or remote, use 
+        // default size
+        if (!test.getLocalTcp().m_support_wnd_scale || 
+            !test.getRemoteTcp().m_support_wnd_scale)
+        {
+        	wndSize = 65535;
+        }
+        test.setLocalOptSndBuf(wndSize);        	
         test.setRemoteOptRcvBuf(wndSize);
-        test.setLocalOptSndBuf(wndSize);
         int wndScale = test.getRemoteScaleFactor();
         //logger.log(Level.INFO, "Using scale factor: {0}", wndScale);
         test.doTestTransfer(1024 * 3000);


### PR DESCRIPTION
This test was failing previously if your OS did not support window scaling.