### PR TITLE
Implemented Builder Pattern to allow turnserver to work

### DIFF
--- a/src/main/java/org/ice4j/ice/Component.java
+++ b/src/main/java/org/ice4j/ice/Component.java
@@ -884,4 +884,19 @@ public class Component
         else
             return Integer.toString(componentID);
     }
+
+    /**
+     * Use builder pattern to allow creation of immutable Component instances,
+	 * from outside the current package.
+	 *
+     * @param componentID the id of this component.
+     * @param mediaStream the {@link IceMediaStream} instance that would be the
+     * parent of this component.
+     * @return Component
+     */
+    public static Component build(int componentID, IceMediaStream mediaStream)
+    {
+        return new Component(componentID, mediaStream);
+    }
+
 }

--- a/src/main/java/org/ice4j/ice/Component.java
+++ b/src/main/java/org/ice4j/ice/Component.java
@@ -887,8 +887,8 @@ public class Component
 
     /**
      * Use builder pattern to allow creation of immutable Component instances,
-	 * from outside the current package.
-	 *
+     * from outside the current package.
+     *
      * @param componentID the id of this component.
      * @param mediaStream the {@link IceMediaStream} instance that would be the
      * parent of this component.

--- a/src/main/java/org/ice4j/ice/IceMediaStream.java
+++ b/src/main/java/org/ice4j/ice/IceMediaStream.java
@@ -906,7 +906,6 @@ public class IceMediaStream
     
     /**
      * Use builder pattern to provide an immutable IceMediaStream instance.
-     * This allows use by turnserver.
      *
      * @param name the name of the media stream
      * @param parentAgent the agent that is handling the session that this

--- a/src/main/java/org/ice4j/ice/IceMediaStream.java
+++ b/src/main/java/org/ice4j/ice/IceMediaStream.java
@@ -903,4 +903,19 @@ public class IceMediaStream
     {
         return remotePassword;
     }
+    
+    /**
+     * Use builder pattern to provide an immutable IceMediaStream instance.
+     * This allows use by turnserver.
+     *
+     * @param name the name of the media stream
+     * @param parentAgent the agent that is handling the session that this
+     * media stream is a part of
+     * @return IceMediaStream
+     */
+    public static IceMediaStream build(Agent parentAgent, String name)
+    {
+        return new IceMediaStream(parentAgent, name);
+    }
+
 }

--- a/src/main/java/org/ice4j/stack/RawMessage.java
+++ b/src/main/java/org/ice4j/stack/RawMessage.java
@@ -119,4 +119,24 @@ public class RawMessage
     {
         return localAddress;
     }
+
+    /**
+     * Use builder pattern to allow creation of immutable RawMessage instances,
+     * from outside the current package. This allows use by turnserver.
+     *
+     * @param messageBytes the message itself.
+     * @param messageLength the number of bytes currently stored in the
+     * <tt>messageBytes</tt> array.
+     * @param remoteAddress the address where the message came from.
+     * @param localAddress the <tt>TransportAddress</tt> that the message was
+     * received on.
+     * @return RawMessage instance
+     */
+    public static RawMessage build(byte[] messageBytes, int messageLength,
+        TransportAddress remoteAddress, TransportAddress localAddress)
+    {
+        return new RawMessage(messageBytes, messageLength, remoteAddress,
+            localAddress);
+    }
+
 }

--- a/src/main/java/org/ice4j/stack/RawMessage.java
+++ b/src/main/java/org/ice4j/stack/RawMessage.java
@@ -122,7 +122,7 @@ public class RawMessage
 
     /**
      * Use builder pattern to allow creation of immutable RawMessage instances,
-     * from outside the current package. This allows use by turnserver.
+     * from outside the current package.
      *
      * @param messageBytes the message itself.
      * @param messageLength the number of bytes currently stored in the

--- a/src/test/java/org/ice4j/pseudotcp/PseudoTcpTestRecvWindow.java
+++ b/src/test/java/org/ice4j/pseudotcp/PseudoTcpTestRecvWindow.java
@@ -390,8 +390,15 @@ public class PseudoTcpTestRecvWindow extends PseudoTcpTestBase
         test.setOptNagling(false);
         test.setOptAckDelay(0);
         int wndSize = 300000;
+        // if window scaling is not supported by either local or remote, use 
+        // default size
+        if (!test.getLocalTcp().m_support_wnd_scale || 
+            !test.getRemoteTcp().m_support_wnd_scale)
+        {
+        	wndSize = 65535;
+        }
+        test.setLocalOptSndBuf(wndSize);        	
         test.setRemoteOptRcvBuf(wndSize);
-        test.setLocalOptSndBuf(wndSize);
         int wndScale = test.getRemoteScaleFactor();
         //logger.log(Level.INFO, "Using scale factor: {0}", wndScale);
         test.doTestTransfer(1024 * 3000);


### PR DESCRIPTION
The turnserver requires instances of Component, IceMediaStream, and RawMessage. The builder pattern has been implemented in these classes to allow immutable instance creation.