### PR TITLE
Added setting of packet port to 0 to prevent out-of-range error.

### DIFF
--- a/src/main/java/org/ice4j/stack/Connector.java
+++ b/src/main/java/org/ice4j/stack/Connector.java
@@ -210,6 +210,7 @@ class Connector
                     packet.getAddress(), packet.getPort()));
                 if (packet.getPort() < 0)
                 {
+                    logger.warning("Out of range packet port, resetting to 0");
                     // force a minimum port of 0 to prevent out of range errors
                     packet.setPort(0);
                 }

--- a/src/main/java/org/ice4j/stack/Connector.java
+++ b/src/main/java/org/ice4j/stack/Connector.java
@@ -206,8 +206,7 @@ class Connector
                 if(!running)
                     return;
 
-                logger.finest("received datagram");
-                logger.finest(String.format("packet - addr: %s port: %d",
+                logger.finest(String.format("received datagram packet - addr: %s port: %d",
                     packet.getAddress(), packet.getPort()));
                 if (packet.getPort() < 0)
                 {

--- a/src/main/java/org/ice4j/stack/Connector.java
+++ b/src/main/java/org/ice4j/stack/Connector.java
@@ -207,6 +207,13 @@ class Connector
                     return;
 
                 logger.finest("received datagram");
+                logger.finest(String.format("packet - addr: %s port: %d",
+                    packet.getAddress(), packet.getPort()));
+                if (packet.getPort() < 0)
+                {
+                    // force a minimum port of 0 to prevent out of range errors
+                    packet.setPort(0);
+                }
 
                 RawMessage rawMessage
                     = new RawMessage(


### PR DESCRIPTION
Setting the port to a minimum of 0 will prevent out-of-range errors like this one on both IPv4 and IPv6.

```
Nov 05, 2015 9:49:37 AM org.ice4j.stack.NetAccessManager handleFatalError
WARNING: Removing connector:ice4j.Connector@[2601:400:4201:7cbd:9048:d9fb:57be:89aa]:3478/tcp status:  running
java.lang.IllegalArgumentException: port out of range:-1
	at java.net.InetSocketAddress.checkPort(InetSocketAddress.java:143)
	at java.net.InetSocketAddress.<init>(InetSocketAddress.java:188)
	at org.ice4j.TransportAddress.<init>(TransportAddress.java:123)
	at org.ice4j.stack.Connector.run(Connector.java:218)
	at java.lang.Thread.run(Thread.java:745)
```