### PR TITLE
Maven release 1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,11 @@
 
   <name>ice4j</name>
   <url>https://github.com/jitsi/ice4j</url>
+  <scm>
+    <url>https://github.com/jitsi/ice4j</url>
+    <connection>scm:git:https://github.com/jitsi/ice4j.git</connection>
+    <developerConnection>scm:git:https://github.com/jitsi/ice4j.git</developerConnection>
+  </scm>
 
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,4 @@
-<project
-    xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -11,7 +8,7 @@
   </parent>
 
   <artifactId>ice4j</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.0</version>
   <packaging>bundle</packaging>
 
   <name>ice4j</name>
@@ -20,6 +17,7 @@
     <url>https://github.com/jitsi/ice4j</url>
     <connection>scm:git:https://github.com/jitsi/ice4j.git</connection>
     <developerConnection>scm:git:https://github.com/jitsi/ice4j.git</developerConnection>
+    <tag>ice4j-1.0</tag>
   </scm>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <artifactId>ice4j</artifactId>
-  <version>1.0</version>
+  <version>1.1-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>ice4j</name>
@@ -17,7 +17,7 @@
     <url>https://github.com/jitsi/ice4j</url>
     <connection>scm:git:https://github.com/jitsi/ice4j.git</connection>
     <developerConnection>scm:git:https://github.com/jitsi/ice4j.git</developerConnection>
-    <tag>ice4j-1.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencies>


### PR DESCRIPTION
These are follow-up commits from publishing ice4j-1.0 on Maven Central. The xml-header is changed automatically by Maven's release-plugin.