### PR TITLE
Fix Javadoc formatting and missing parameters

### DIFF
--- a/src/main/java/org/ice4j/ChannelDataMessageEvent.java
+++ b/src/main/java/org/ice4j/ChannelDataMessageEvent.java
@@ -106,10 +106,13 @@ public class ChannelDataMessageEvent
     {
         return this.remoteAddress;
     }
-    
+
     /**
      * Gets the <tt>TransportAddress</tt> which is local address on which this
      * event was received.
+     * 
+     * @return the <tt>TransportAddress</tt> which is local address on which
+     *         this event was received.
      */
     public TransportAddress getLocalAddress()
     {

--- a/src/main/java/org/ice4j/TransportAddress.java
+++ b/src/main/java/org/ice4j/TransportAddress.java
@@ -216,7 +216,7 @@ public class TransportAddress
      * address if both the InetAddresses (or hostnames if it is unresolved),
      * port numbers, and <tt>Transport</tt>s are equal.
      *
-     * If both addresses are unresolved, then the hostname, the port & and
+     * If both addresses are unresolved, then the hostname, the port and
      * the <tt>Transport</tt> are compared.
      *
      * @param   obj   the object to compare against.

--- a/src/main/java/org/ice4j/attribute/AddressAttribute.java
+++ b/src/main/java/org/ice4j/attribute/AddressAttribute.java
@@ -24,34 +24,32 @@ import org.ice4j.*;
 /**
  * This class is used to represent Stun attributes that contain an address. Such
  * attributes are:
- *<p>
- * MAPPED-ADDRESS <br/>
- * RESPONSE-ADDRESS <br/>
- * SOURCE-ADDRESS <br/>
- * CHANGED-ADDRESS <br/>
- * REFLECTED-FROM <br/>
- * ALTERNATE-SERVER <br/>
- * XOR-PEER-ADDRESS <br/>
- * XOR-RELAYED-ADDRESS <br/>
- *</p>
+ *<ul>
+ * <li>MAPPED-ADDRESS
+ * <li>RESPONSE-ADDRESS
+ * <li>SOURCE-ADDRESS
+ * <li>CHANGED-ADDRESS
+ * <li>REFLECTED-FROM
+ * <li>ALTERNATE-SERVER
+ * <li>XOR-PEER-ADDRESS
+ * <li>XOR-RELAYED-ADDRESS
+ *</ul>
  *<p>
  * The different attributes are distinguished by the attributeType of
- * org.ice4j.attribute.Attribute.
- *</p>
+ * {@link Attribute}.
  *<p>
  * Address attributes indicate the mapped IP address and
  * port.  They consist of an eight bit address family, and a sixteen bit
  * port, followed by a fixed length value representing the IP address.
- *<code>
- *  0                   1                   2                   3          <br/>
- *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1        <br/>
- * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+       <br/>
- * |x x x x x x x x|    Family     |           Port                |       <br/>
- * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+       <br/>
- * |                             Address                           |       <br/>
- * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+       <br/>
- *                                                                         <br/>
- * </p>
+ *<pre>
+ *  0                   1                   2                   3   
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |x x x x x x x x|    Family     |           Port                |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |                             Address                           |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * </pre>
  * <p>
  * The port is a network byte ordered representation of the mapped port.
  * The address family is always 0x01, corresponding to IPv4.  The first

--- a/src/main/java/org/ice4j/attribute/Attribute.java
+++ b/src/main/java/org/ice4j/attribute/Attribute.java
@@ -22,53 +22,54 @@ import org.ice4j.*;
 /**
  * After the header are 0 or more attributes.  Each attribute is TLV
  * encoded, with a 16 bit type, 16 bit length, and variable value:
+ *<pre>
+ *     0                   1                   2                   3   
+ *     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |         Type                  |            Length             |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |                             Value                             ....
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  *
- *     0                   1                   2                   3       <br/>
- *     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1     <br/>
- *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+    <br/>
- *    |         Type                  |            Length             |    <br/>
- *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+    <br/>
- *    |                             Value                             .... <br/>
- *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+    <br/>
- *<br/>
- *    The following types are defined:<br/>
- *<br/>
- * STUN attributes:<br/>
- *    0x0001: MAPPED-ADDRESS                                               <br/>
- *    0x0002: RESPONSE-ADDRESS                                             <br/>
- *    0x0003: CHANGE-REQUEST                                               <br/>
- *    0x0004: SOURCE-ADDRESS                                               <br/>
- *    0x0005: CHANGED-ADDRESS                                              <br/>
- *    0x0006: USERNAME                                                     <br/>
- *    0x0007: PASSWORD                                                     <br/>
- *    0x0008: MESSAGE-INTEGRITY                                            <br/>
- *    0x0009: ERROR-CODE                                                   <br/>
- *    0x000a: UNKNOWN-ATTRIBUTES                                           <br/>
- *    0x000b: REFLECTED-FROM                                               <br/>
- *    0x0014: REALM                                                        <br/>
- *    0x0015: NONCE                                                        <br/>
- *    0x0020: XOR-MAPPED-ADDRESS                                           <br/>
- *    0x8022: SOFTWARE                                                     <br/>
- *    0x8023: ALTERNATE-SERVER                                             <br/>
- *    0x8028: FINGERPRINT                                                  <br/>
- *                                                                         <br/>
- * TURN attributes:<br/>
- *    0x000C: CHANNEL-NUMBER                                               <br/>
- *    0x000D: LIFETIME                                                     <br/>
- *    0x0012: XOR-PEER-ADDRESS                                             <br/>
- *    0x0013: DATA                                                         <br/>
- *    0x0016: XOR-RELAYED-ADDRESS                                          <br/>
- *    0x0018: EVEN-PORT                                                    <br/>
- *    0x0019: REQUESTED-TRANSPORT                                          <br/>
- *    0x001A: DONT-FRAGMENT                                                <br/>
- *    0x0022: RESERVATION-TOKEN                                            <br/>
+ *    The following types are defined:
  *
- * ICE attributes:<br/>
- *    0x0024: PRIORITY                                                     <br/>
- *    0x0025: USE-CANDIDATE                                                <br/>
- *    0x8029: ICE-CONTROLLED                                               <br/>
- *    0x802A: ICE-CONTROLLING                                              <br/>
+ * STUN attributes:
+ *    0x0001: MAPPED-ADDRESS
+ *    0x0002: RESPONSE-ADDRESS
+ *    0x0003: CHANGE-REQUEST
+ *    0x0004: SOURCE-ADDRESS
+ *    0x0005: CHANGED-ADDRESS
+ *    0x0006: USERNAME
+ *    0x0007: PASSWORD
+ *    0x0008: MESSAGE-INTEGRITY
+ *    0x0009: ERROR-CODE
+ *    0x000a: UNKNOWN-ATTRIBUTES
+ *    0x000b: REFLECTED-FROM
+ *    0x0014: REALM
+ *    0x0015: NONCE
+ *    0x0020: XOR-MAPPED-ADDRESS
+ *    0x8022: SOFTWARE
+ *    0x8023: ALTERNATE-SERVER
+ *    0x8028: FINGERPRINT
  *
+ * TURN attributes:
+ *    0x000C: CHANNEL-NUMBER
+ *    0x000D: LIFETIME
+ *    0x0012: XOR-PEER-ADDRESS
+ *    0x0013: DATA
+ *    0x0016: XOR-RELAYED-ADDRESS
+ *    0x0018: EVEN-PORT
+ *    0x0019: REQUESTED-TRANSPORT
+ *    0x001A: DONT-FRAGMENT
+ *    0x0022: RESERVATION-TOKEN
+ *
+ * ICE attributes:
+ *    0x0024: PRIORITY
+ *    0x0025: USE-CANDIDATE
+ *    0x8029: ICE-CONTROLLED
+ *    0x802A: ICE-CONTROLLING
+ * </pre>
+ * 
  * @author Emil Ivov
  * @author Sebastien Vincent
  * @author Namal Senarathne

--- a/src/main/java/org/ice4j/attribute/AttributeFactory.java
+++ b/src/main/java/org/ice4j/attribute/AttributeFactory.java
@@ -544,7 +544,8 @@ public class AttributeFactory
      *
      * @param priority the priority value
      * @return the created PriorityAttribute
-     * @throws IllegalArgumentException if priority < 0 or priority > (2^31 - 1)
+     * @throws IllegalArgumentException if priority &lt; 0 or priority &gt;
+     *             (2^31 - 1)
      */
     public static PriorityAttribute createPriorityAttribute(long priority)
                     throws IllegalArgumentException

--- a/src/main/java/org/ice4j/attribute/ChangeRequestAttribute.java
+++ b/src/main/java/org/ice4j/attribute/ChangeRequestAttribute.java
@@ -24,13 +24,13 @@ import org.ice4j.*;
  * attribute is used by the client to request that the server use a different
  * address and/or port when sending the response.  The attribute is 32 bits
  * long, although only two bits (A and B) are used:
- *
- * 0                   1                   2                   3           <br/>
- * 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1         <br/>
- * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+       <br/>
- * |0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 A B 0|       <br/>
- * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+       <br/>
- *
+ * <pre>
+ * 0                   1                   2                   3    
+ * 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1  
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 A B 0|
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * </pre>
  * The meaning of the flags is:
  *
  * A: This is the "change IP" flag.  If true, it requests the server

--- a/src/main/java/org/ice4j/attribute/ChannelNumberAttribute.java
+++ b/src/main/java/org/ice4j/attribute/ChannelNumberAttribute.java
@@ -169,7 +169,7 @@ public class ChannelNumberAttribute extends Attribute
     /**
      * Determines if the channelNo is in valid range.
      * @param channelNo the channelNo to validate.
-     * @return true if channnelNo is >= 0x4000.
+     * @return true if channnelNo is &gt;= 0x4000.
      */
     public static boolean isValidRange(char channelNo)
     {

--- a/src/main/java/org/ice4j/attribute/DataAttribute.java
+++ b/src/main/java/org/ice4j/attribute/DataAttribute.java
@@ -52,7 +52,7 @@ public class DataAttribute
     private final boolean padding;
 
     /**
-     * Constructor.
+     * Creates a new instance of this class with padding enabled.
      */
     protected DataAttribute()
     {
@@ -60,7 +60,9 @@ public class DataAttribute
     }
 
     /**
-     * Constructor.
+     * Creates a new instance of this class.
+     * @param padding true to pad the data if the length is not on a word
+     * boundary.
      */
     protected DataAttribute(boolean padding)
     {

--- a/src/main/java/org/ice4j/attribute/EvenPortAttribute.java
+++ b/src/main/java/org/ice4j/attribute/EvenPortAttribute.java
@@ -24,8 +24,8 @@ import org.ice4j.*;
  * server to allocate an even port and optionally allocate
  * the next higher port number.
  *
- * There are one flag supported : <br/>
- * R : ask to reserve a second port.<br/>
+ * There is one flag supported: <br>
+ * R : ask to reserve a second port.
  *
  * @author Sebastien Vincent
  */

--- a/src/main/java/org/ice4j/attribute/MessageIntegrityAttribute.java
+++ b/src/main/java/org/ice4j/attribute/MessageIntegrityAttribute.java
@@ -37,7 +37,6 @@ import org.ice4j.stack.*;
  * The key for the HMAC depends on whether long-term or short-term
  * credentials are in use.  For long-term credentials, the key is 16
  * bytes:
- * <p>
  * <pre>
  *          key = MD5(username ":" realm ":" SASLprep(password))
  * </pre>
@@ -54,7 +53,6 @@ import org.ice4j.stack.*;
  * 0x8493fbc53ba582fb4c044c456bdc40eb.
  * <p>
  * For short-term credentials:
- * <p>
  * <pre>
  *                        key = SASLprep(password)
  * </pre>

--- a/src/main/java/org/ice4j/ice/Agent.java
+++ b/src/main/java/org/ice4j/ice/Agent.java
@@ -373,7 +373,7 @@ public class Agent
      * all and only local candidates.
      *
      * @throws IllegalArgumentException if either <tt>minPort</tt> or
-     * <tt>maxPort</tt> is not a valid port number or if <tt>minPort >
+     * <tt>maxPort</tt> is not a valid port number or if <tt>minPort &gt;
      * maxPort</tt>, or if <tt>transport</tt> is not currently supported.
      * @throws IOException if an error occurs while the underlying resolver lib
      * is using sockets.
@@ -1023,6 +1023,7 @@ public class Agent
      * candidate foundations. We use the <tt>FoundationsRegistry</tt> to keep
      * track of the foundations we assign within a session (i.e. the entire life
      * time of an <tt>Agent</tt>)
+     * @return the {@link FoundationsRegistry} of this agent
      */
     public final FoundationsRegistry getFoundationsRegistry()
     {
@@ -1891,7 +1892,6 @@ public class Agent
      * @return the value of the <tt>Ta</tt> pace timer according to the
      * number and type of {@link IceMediaStream}s this agent will be using or
      * a pre-configured value if the application has set one.
-     * <p>
      */
     protected long calculateTa()
     {

--- a/src/main/java/org/ice4j/ice/CandidatePair.java
+++ b/src/main/java/org/ice4j/ice/CandidatePair.java
@@ -367,7 +367,7 @@ public class CandidatePair
      * agent. Let D be the priority for the candidate provided by the
      * controlled agent. The priority for a pair is computed as:
      * <p>
-     * <i>pair priority = 2^32*MIN(G,D) + 2*MAX(G,D) + (G>D?1:0)</i>
+     * <i>pair priority = 2^32*MIN(G,D) + 2*MAX(G,D) + (G&gt;D?1:0)</i>
      * <p>
      * This formula ensures a unique priority for each pair. Once the priority
      * is assigned, the agent sorts the candidate pairs in decreasing order of

--- a/src/main/java/org/ice4j/ice/CandidateTcpType.java
+++ b/src/main/java/org/ice4j/ice/CandidateTcpType.java
@@ -74,6 +74,8 @@ public enum CandidateTcpType
      * Parses the string <tt>candidateTcpTypeName</tt> and return the
      * corresponding <tt>CandidateTcpType</tt> instance.
      *
+     * @param candidateTcpTypeName the string to parse
+     * @return candidateTcpTypeName as an Enum
      * @throws IllegalArgumentException in case <tt>candidateTcpTypeName</tt> is
      * not a valid or currently supported candidate TCP type.
      */

--- a/src/main/java/org/ice4j/ice/CheckListState.java
+++ b/src/main/java/org/ice4j/ice/CheckListState.java
@@ -20,17 +20,17 @@ package org.ice4j.ice;
 /**
  * Everty <tt>CheckList</tt> is associated with a state, which captures the
  * state of ICE checks for that media stream. There are three states:
- * <p/>
+ * <br>
  * Running:  In this state, ICE checks are still in progress for this
  * media stream.
- * <p/>
+ * <br>
  * Completed:  In this state, ICE checks have produced nominated pairs
  * for each component of the media stream.  Consequently, ICE has succeeded and
  * media can be sent.
- * <p/>
+ * <br>
  * Failed:  In this state, the ICE checks have not completed successfully for
  * this media stream.
- * <p/>
+ * <br>
  * When a check list is first constructed as the consequence of an offer/answer
  * exchange, it is placed in the Running state.
  *

--- a/src/main/java/org/ice4j/ice/IceMediaStream.java
+++ b/src/main/java/org/ice4j/ice/IceMediaStream.java
@@ -422,7 +422,7 @@ public class IceMediaStream
      *  candidate with its base. Once this has been done, we remove each pair
      *  where the local and remote candidates are identical to the local and
      *  remote candidates of a pair higher up on the priority list.
-     *  <p/>
+     *  <br>
      *  In addition, in order to limit the attacks described in Section 18.5.2
      *  of the ICE spec, we limit the total number of pairs and hence
      *  (connectivity checks) to a specific value, (a total of 100 by default).

--- a/src/main/java/org/ice4j/ice/harvest/HostCandidateHarvester.java
+++ b/src/main/java/org/ice4j/ice/harvest/HostCandidateHarvester.java
@@ -248,7 +248,7 @@ public class HostCandidateHarvester
      * @param transport transport protocol used
      *
      * @throws IllegalArgumentException if either <tt>minPort</tt> or
-     * <tt>maxPort</tt> is not a valid port number, <tt>minPort >
+     * <tt>maxPort</tt> is not a valid port number, <tt>minPort &gt;
      * maxPort</tt> or if transport is not supported.
      * @throws IOException if an error occurs while the underlying resolver lib
      * is using sockets.

--- a/src/main/java/org/ice4j/ice/harvest/TcpHarvester.java
+++ b/src/main/java/org/ice4j/ice/harvest/TcpHarvester.java
@@ -186,6 +186,9 @@ public class TcpHarvester
      * interfaces.
      *
      * @param port the port to listen on.
+     * @throws IOException when {@link StackProperties#ALLOWED_ADDRESSES} or
+     * {@link StackProperties#BLOCKED_ADDRESSES} contains invalid values, or
+     * if an I/O error occurs.
      */
     public TcpHarvester(int port)
         throws IOException
@@ -200,6 +203,9 @@ public class TcpHarvester
      *
      * @param port the port to listen on.
      * @param ssltcp <tt>true</tt> to use ssltcp; otherwise, <tt>false</tt>
+     * @throws IOException when {@link StackProperties#ALLOWED_ADDRESSES} or
+     * {@link StackProperties#BLOCKED_ADDRESSES} contains invalid values, or
+     * if an I/O error occurs.
      */
     public TcpHarvester(int port, boolean ssltcp)
             throws IOException
@@ -217,6 +223,9 @@ public class TcpHarvester
      * @param port the port to listen on.
      * @param interfaces the interfaces to listen on.
      * @param ssltcp <tt>true</tt> to use ssltcp; otherwise, <tt>false</tt>
+     * @throws IOException when {@link StackProperties#ALLOWED_ADDRESSES} or
+     * {@link StackProperties#BLOCKED_ADDRESSES} contains invalid values, or
+     * if an I/O error occurs.
      */
     public TcpHarvester(int port,
                                         List<NetworkInterface> interfaces,
@@ -231,6 +240,9 @@ public class TcpHarvester
      * listen on the specified list of <tt>TransportAddress</tt>es.
      *
      * @param transportAddresses the transport addresses to listen on.
+     * @throws IOException when {@link StackProperties#ALLOWED_ADDRESSES} or
+     * {@link StackProperties#BLOCKED_ADDRESSES} contains invalid values, or
+     * if an I/O error occurs.
      */
     public TcpHarvester(
             List<TransportAddress> transportAddresses)
@@ -245,6 +257,9 @@ public class TcpHarvester
      *
      * @param transportAddresses the transport addresses to listen on.
      * @param ssltcp <tt>true</tt> to use ssltcp; otherwise, <tt>false</tt>
+     * @throws IOException when {@link StackProperties#ALLOWED_ADDRESSES} or
+     * {@link StackProperties#BLOCKED_ADDRESSES} contains invalid values, or
+     * if an I/O error occurs.
      */
     public TcpHarvester(
             List<TransportAddress> transportAddresses,
@@ -262,6 +277,8 @@ public class TcpHarvester
      * allocation.
      *
      * @param transportAddresses the list of addresses to add.
+     * @throws IOException when {@link StackProperties#ALLOWED_ADDRESSES} or
+     * {@link StackProperties#BLOCKED_ADDRESSES} contains invalid values.
      */
     private void addLocalAddresses(List<TransportAddress> transportAddresses)
         throws IOException
@@ -605,6 +622,7 @@ public class TcpHarvester
     /**
      * Initializes {@link #serverSocketChannels}, creates and starts the threads
      * used by this instance.
+     * @throws IOException if an I/O error occurs
      */
     private void init()
         throws IOException

--- a/src/main/java/org/ice4j/message/Message.java
+++ b/src/main/java/org/ice4j/message/Message.java
@@ -361,27 +361,27 @@ public abstract class Message
      *
      * For classic STUN :
      *
-     *
-     *                                         Binding  Shared  Shared  Shared        <br/>
-     *                       Binding  Binding  Error    Secret  Secret  Secret        <br/>
-     *   Att.                Req.     Resp.    Resp.    Req.    Resp.   Error         <br/>
-     *                                                                  Resp.         <br/>
-     *   _____________________________________________________________________        <br/>
-     *   MAPPED-ADDRESS      N/A      M        N/A      N/A     N/A     N/A           <br/>
-     *   RESPONSE-ADDRESS    O        N/A      N/A      N/A     N/A     N/A           <br/>
-     *   CHANGE-REQUEST      O        N/A      N/A      N/A     N/A     N/A           <br/>
-     *   SOURCE-ADDRESS      N/A      M        N/A      N/A     N/A     N/A           <br/>
-     *   CHANGED-ADDRESS     N/A      M        N/A      N/A     N/A     N/A           <br/>
-     *   USERNAME            O        N/A      N/A      N/A     M       N/A           <br/>
-     *   PASSWORD            N/A      N/A      N/A      N/A     M       N/A           <br/>
-     *   MESSAGE-INTEGRITY   O        O        N/A      N/A     N/A     N/A           <br/>
-     *   ERROR-CODE          N/A      N/A      M        N/A     N/A     M             <br/>
-     *   UNKNOWN-ATTRIBUTES  N/A      N/A      C        N/A     N/A     C             <br/>
-     *   REFLECTED-FROM      N/A      C        N/A      N/A     N/A     N/A           <br/>
-     *   XOR-MAPPED-ADDRESS  N/A      M        N/A      N/A     N/A     N/A           <br/>
-     *   XOR-ONLY            O        N/A      N/A      N/A     N/A     N/A           <br/>
-     *   SOFTWARE            N/A      O        O        N/A     O       O             <br/>
-     *
+     * <pre>
+     *                                         Binding  Shared  Shared  Shared
+     *                       Binding  Binding  Error    Secret  Secret  Secret
+     *   Att.                Req.     Resp.    Resp.    Req.    Resp.   Error 
+     *                                                                  Resp. 
+     *   _____________________________________________________________________
+     *   MAPPED-ADDRESS      N/A      M        N/A      N/A     N/A     N/A   
+     *   RESPONSE-ADDRESS    O        N/A      N/A      N/A     N/A     N/A   
+     *   CHANGE-REQUEST      O        N/A      N/A      N/A     N/A     N/A   
+     *   SOURCE-ADDRESS      N/A      M        N/A      N/A     N/A     N/A   
+     *   CHANGED-ADDRESS     N/A      M        N/A      N/A     N/A     N/A   
+     *   USERNAME            O        N/A      N/A      N/A     M       N/A   
+     *   PASSWORD            N/A      N/A      N/A      N/A     M       N/A   
+     *   MESSAGE-INTEGRITY   O        O        N/A      N/A     N/A     N/A   
+     *   ERROR-CODE          N/A      N/A      M        N/A     N/A     M     
+     *   UNKNOWN-ATTRIBUTES  N/A      N/A      C        N/A     N/A     C     
+     *   REFLECTED-FROM      N/A      C        N/A      N/A     N/A     N/A   
+     *   XOR-MAPPED-ADDRESS  N/A      M        N/A      N/A     N/A     N/A   
+     *   XOR-ONLY            O        N/A      N/A      N/A     N/A     N/A   
+     *   SOFTWARE            N/A      O        O        N/A     O       O     
+     * </pre>
      */
     public static final byte N_A = 0;
 
@@ -710,9 +710,9 @@ public abstract class Message
      *
      * @param attributeType the id of the attribute to check .
      *
-     * @return Message.N_A - for not applicable <br/>
-     *         Message.C   - for case depending <br/>
-     *         Message.N_A - for not applicable <br/>
+     * @return Message.N_A - for not applicable <br>
+     *         Message.C   - for case depending <br>
+     *         Message.N_A - for not applicable <br>
      */
     protected byte getAttributePresentity(char attributeType)
     {

--- a/src/main/java/org/ice4j/message/MessageFactory.java
+++ b/src/main/java/org/ice4j/message/MessageFactory.java
@@ -1353,6 +1353,7 @@ public class MessageFactory
      * mandatory headers.
      * @throws IllegalArgumentException if there was something wrong with the
      * way we are trying to create the Request.
+     * @throws StunException when the transaction id is not valid.
      */
     public static Indication createConnectionAttemptIndication(
         int connectionIdValue, TransportAddress peerAddress,

--- a/src/main/java/org/ice4j/pseudotcp/PseudoTCPBase.java
+++ b/src/main/java/org/ice4j/pseudotcp/PseudoTCPBase.java
@@ -364,9 +364,9 @@ public class PseudoTCPBase
     }
 
     /**
-     * Set the MTU value
+     * Set the MTU (maximum transmission unit) value
      *
-     * @param mtu
+     * @param mtu the new MTU value
      */
     public void notifyMTU(int mtu)
     {
@@ -680,11 +680,13 @@ public class PseudoTCPBase
     }
 
     /**
-     *
-     * @param buffer
-     * @param len
+     * Reads the data available in receive buffer. This method returns 0 if
+     * there's no data available at the moment.
+     * 
+     * @param buffer destination buffer
+     * @param len bytes to be read
      * @return received byte count
-     * @throws IOException
+     * @throws IOException if the protocol is not in the connected state
      */
     public int recv(byte[] buffer, int len) throws IOException
     {
@@ -692,11 +694,12 @@ public class PseudoTCPBase
     }
 
     /**
-     *
-     * @param buffer
-     * @param len
+     * Enqueues data in the send buffer
+     * 
+     * @param buffer source data buffer
+     * @param len bytes count to be sent
      * @return sent byte count
-     * @throws IOException
+     * @throws IOException if the protocol is not in connected state
      */
     public int send(byte[] buffer, int len) throws IOException
     {
@@ -875,6 +878,9 @@ public class PseudoTCPBase
 
     /**
      * Method can be used in debugging utilities to parse PTCP segment
+     * @param buffer data to parse
+     * @param size length of the data in the buffer
+     * @return the parsed segment
      */
     public static Segment parseSeg(byte[] buffer, int size)
     {
@@ -898,11 +904,11 @@ public class PseudoTCPBase
         
         return seg;
     }
-    
+
     /**
      * Can be used to convert segments to text
      * 
-     * @param seg
+     * @param seg the {@link Segment} to format
      * @return segment in readable text form
      */
     public static String segToStr(Segment seg)

--- a/src/main/java/org/ice4j/pseudotcp/PseudoTcpNotify.java
+++ b/src/main/java/org/ice4j/pseudotcp/PseudoTcpNotify.java
@@ -29,35 +29,35 @@ public interface PseudoTcpNotify
 {
     /**
      * Called when TCP enters opened state
-     * @param tcp 
+     * @param tcp the socket that was opened
      */
     void onTcpOpen(PseudoTCPBase tcp);
 
     /**
      * Called when any data is available in read buffer
-     * @param tcp 
+     * @param tcp the socket that became readable
      */
     void onTcpReadable(PseudoTCPBase tcp);
 
     /**
      * Called when there is free space available in the send buffer
-     * @param tcp 
+     * @param tcp the socket that became writable
      */
     void onTcpWriteable(PseudoTCPBase tcp);
 
     /**
      * Called when tcp enters closed state
-     * @param tcp
+     * @param tcp the socket that was closed
      * @param e null means no error
      */
     void onTcpClosed(PseudoTCPBase tcp, IOException e);
 
     /**
      * Called when protocol requests packet transfer through the network.
-     * @param tcp
-     * @param buffer data
+     * @param tcp the socket on which the write occurred
+     * @param buffer the data that was written
      * @param len data length
      * @return the result, see {@link WriteResult} description for more info
-     */    
+     */
     WriteResult tcpWritePacket(PseudoTCPBase tcp, byte[] buffer, int len);
 }

--- a/src/main/java/org/ice4j/pseudotcp/PseudoTcpSocket.java
+++ b/src/main/java/org/ice4j/pseudotcp/PseudoTcpSocket.java
@@ -52,7 +52,7 @@ public class PseudoTcpSocket extends Socket
      * Set conversation ID for the socket
      * Must be called on unconnected socket
      * 
-     * @param convID
+     * @param convID the conversation ID to set
      * @throws IllegalStateException when called on connected or closed socket
      */
     public void setConversationID(long convID)
@@ -62,8 +62,8 @@ public class PseudoTcpSocket extends Socket
     }
 	
     /**
-     * Sets MTU value
-     * @param mtu
+     * Sets MTU (maximum transmission unit) value
+     * @param mtu  the MTU value
      */
 	public void setMTU(int mtu)
 	{
@@ -71,7 +71,7 @@ public class PseudoTcpSocket extends Socket
 	}
 	
 	/**
-	 * 
+	 * Gets MTU (maximum transmission unit) value
 	 * @return MTU value
 	 */
 	public int getMTU()
@@ -80,9 +80,10 @@ public class PseudoTcpSocket extends Socket
 	}
 	
 	/**
-	 * 
+	 * Sets an {@link Option} on this socket.
 	 * @return PseudoTCP option value
 	 * 
+	 * @param option the option to set on this socket.
 	 * @see Option
 	 */
 	public long getOption(Option option)
@@ -116,7 +117,7 @@ public class PseudoTcpSocket extends Socket
 
 	/**
      * Sets debug name that will be displayed in log messages for this socket
-     * @param debugName 
+     * @param debugName the name of this socket for debug messages
      */
     public void setDebugName(String debugName)
     {
@@ -265,6 +266,7 @@ public class PseudoTcpSocket extends Socket
      *                      accepted as remote packet's source
      * @param timeout connection accept timeout value in milliseconds, after
      *                which the exception will be thrown.
+     * @throws IOException if socket is closed or timeout expires
      */
     public void accept(SocketAddress remoteAddress, int timeout)
             throws IOException

--- a/src/main/java/org/ice4j/pseudotcp/PseudoTcpSocketFactory.java
+++ b/src/main/java/org/ice4j/pseudotcp/PseudoTcpSocketFactory.java
@@ -67,9 +67,10 @@ public class PseudoTcpSocketFactory
 
     /**
      * Creates socket bound to local <tt>sockAddr</tt>
-     * @param sockAddr
+     * @param sockAddr address for the pseudo socket
      * @return socket bound to local address
-     * @throws IOException
+     * @throws IOException if the socket could not be opened, or the socket
+     * could not bind to the specified local port.
      */
     public Socket createBoundSocket(InetSocketAddress sockAddr) 
         throws IOException
@@ -110,9 +111,10 @@ public class PseudoTcpSocketFactory
     /**
      * Creates a socket that will run on given <tt>datagramSocket</tt>
      * 
-     * @param datagramSocket
+     * @param datagramSocket the socket to run on
      * @return new socket running on given <tt>datagramSocket</tt>
-     * @throws SocketException 
+     * @throws SocketException if there is an error in the underlying protocol,
+     * such as a TCP error.
      */
     public PseudoTcpSocket createSocket(DatagramSocket datagramSocket) 
         throws SocketException

--- a/src/main/java/org/ice4j/pseudotcp/util/ByteFifoBuffer.java
+++ b/src/main/java/org/ice4j/pseudotcp/util/ByteFifoBuffer.java
@@ -62,12 +62,12 @@ public class ByteFifoBuffer
     }
 
     /**
-     * Method reads <tt>count</tt> bytes into <tt>out_buffer</tt>. 
+     * Reads <tt>count</tt> bytes into <tt>out_buffer</tt>. 
      * Current read position is incremented by count of bytes 
      * that has been successfully read.
      *
-     * @param out_buffer
-     * @param count
+     * @param out_buffer read count bytes into this buffer
+     * @param count number of bytes to read into the out_buffer
      * @return bytes successfully read
      */
     public int read(byte[] out_buffer, int count)
@@ -77,8 +77,9 @@ public class ByteFifoBuffer
     
     /**
      * Read with buffer offset
-     * @param out_buffer
-     * @param buff_offset
+     * 
+     * @param out_buffer read count bytes into this buffer
+     * @param buff_offset offset where to start writing into out_buffer
      * @param count bytes to read
      * @return read byte count
      */
@@ -95,8 +96,8 @@ public class ByteFifoBuffer
 
     /**
      * Limits <tt>desiredReadCount</tt> to count that is actually available
-     * @param desiredReadCount
-     * @return 
+     * @param desiredReadCount desired amount of bytes to read
+     * @return min(buffered, desiredReadCount)
      */
     private int readLimit(int desiredReadCount)
     {
@@ -154,8 +155,8 @@ public class ByteFifoBuffer
     /**
      * Writes <tt>count</tt> of bytes from the <tt>buffer</tt>
      *
-     * @param buffer
-     * @param count
+     * @param buffer data to write into the buffer
+     * @param count number of bytes to read from the buffer
      * @return bytes successfully written to buffer
      */
     public int write(byte[] buffer, int count)
@@ -164,10 +165,11 @@ public class ByteFifoBuffer
     }
 
     /**
+     * Writes data into the buffer.
      *
      * @param data source data
      * @param offset source buffer's offset
-     * @param count
+     * @param count number of bytes to read from the buffer
      * @return byte count actually read
      */
     public int write(byte[] data, int offset, int count)
@@ -262,7 +264,7 @@ public class ByteFifoBuffer
     /**
      * Advances current buffer's write position by <tt>count</tt> bytes
      * 
-     * @param count
+     * @param count number of bytes to move forward
      */
     public void consumeWriteBuffer(int count)
         throws IllegalArgumentException,
@@ -286,7 +288,7 @@ public class ByteFifoBuffer
     /**
      * Sets new buffer's capacity
      *
-     * @param new_size
+     * @param new_size number of bytes
      * @return <tt>true</tt> if operation is possible to perform, that is if new
      * buffered data fits into new buffer
      */
@@ -305,7 +307,7 @@ public class ByteFifoBuffer
     /**
      * Aligns current read position by <tt>count</tt>
      *
-     * @param count
+     * @param count number of bytes to move the read position
      * @throws BufferUnderflowException if new position exceeds buffered data
      * count
      */
@@ -332,7 +334,7 @@ public class ByteFifoBuffer
     /**
      * Reads <tt>count</tt> bytes from buffer without storing new read position
      *
-     * @param dst_buff
+     * @param dst_buff buffer to write the read data to
      * @param dst_buff_offset offset of destination buffer
      * @param count bytes to read
      * @param offset from current read position
@@ -358,8 +360,8 @@ public class ByteFifoBuffer
      * Writes <tt>count</tt> bytes from <tt>data</tt> to the buffer without
      * affecting buffer's write position
      *
-     * @param data
-     * @param count
+     * @param data the data to write to the buffer
+     * @param count number of bytes to read from data
      * @param nOffset from buffer's write position
      * @return bytes successfully written
      */

--- a/src/main/java/org/ice4j/security/CredentialsManager.java
+++ b/src/main/java/org/ice4j/security/CredentialsManager.java
@@ -27,7 +27,7 @@ import java.util.*;
  * possible users (such as STUN/TURN servers) or others that would only work
  * with a few, like for example an ICE implementation.
  *
- * @todo just throwing a user name at the manager and expecting it to find
+ * TODO: just throwing a user name at the manager and expecting it to find
  * an authority that knows about it may lead to ambiguities so we may need
  * to add other parameters in here that would allow us to better select an
  * authority.

--- a/src/main/java/org/ice4j/socket/DelegatingServerSocket.java
+++ b/src/main/java/org/ice4j/socket/DelegatingServerSocket.java
@@ -47,7 +47,7 @@ public class DelegatingServerSocket
      *
      * @param delegate the {@code ServerSocket} the new instance is to delegate
      * (it method calls) to
-     * @throws IOException
+     * @throws IOException never thrown
      */
     public DelegatingServerSocket(ServerSocket delegate)
         throws IOException
@@ -64,7 +64,7 @@ public class DelegatingServerSocket
      * (it method calls) to
      * @param channel the {@code ServerSocketChannel} to be reported by the new
      * instance or {@code null} to report the one of {@code delegate}
-     * @throws IOException
+     * @throws IOException never thrown
      */
     public DelegatingServerSocket(
             ServerSocket delegate,

--- a/src/main/java/org/ice4j/socket/DelegatingSocket.java
+++ b/src/main/java/org/ice4j/socket/DelegatingSocket.java
@@ -155,8 +155,9 @@ public class DelegatingSocket
     /**
      * Initializes a new <tt>DelegatingSocket</tt>.
      *
-     * @param address
-     * @param port
+     * @param address ignored
+     * @param port ignored
+     * @throws IOException never thrown
      * @see Socket#Socket(InetAddress, int)
      */
     public DelegatingSocket(InetAddress address, int port)
@@ -168,11 +169,12 @@ public class DelegatingSocket
     /**
      * Initializes a new <tt>DelegatingSocket</tt>.
      *
-     * @param address
-     * @param port
-     * @param localAddr
-     * @param localPort
+     * @param address ignored
+     * @param port ignored
+     * @param localAddr ignored
+     * @param localPort ignored
      * @see Socket#Socket(InetAddress, int, InetAddress, int)
+     * @throws IOException never thrown
      */
     public DelegatingSocket(
             InetAddress address, int port,
@@ -185,7 +187,7 @@ public class DelegatingSocket
     /**
      * Initializes a new <tt>DelegatingSocket</tt>.
      *
-     * @param proxy
+     * @param proxy ignored
      * @see Socket#Socket(Proxy)
      */
     public DelegatingSocket(Proxy proxy)
@@ -243,7 +245,8 @@ public class DelegatingSocket
     /**
      * Initializes a new <tt>DelegatingSocket</tt>.
      *
-     * @param impl
+     * @param impl  ignored
+     * @throws SocketException never thrown
      * @see Socket#Socket(SocketImpl)
      */
     protected DelegatingSocket(SocketImpl impl)
@@ -255,8 +258,10 @@ public class DelegatingSocket
     /**
      * Initializes a new <tt>DelegatingSocket</tt>.
      *
-     * @param host
-     * @param port
+     * @param host ignored
+     * @param port ignored
+     * @throws UnknownHostException never thrown
+     * @throws IOException never thrown
      * @see Socket#Socket(String, int)
      */
     public DelegatingSocket(String host, int port)
@@ -268,10 +273,10 @@ public class DelegatingSocket
     /**
      * Initializes a new <tt>DelegatingSocket</tt>.
      *
-     * @param host
-     * @param port
-     * @param localAddr
-     * @param localPort
+     * @param host ignored
+     * @param port ignored
+     * @param localAddr ignored
+     * @param localPort ignored
      * @see Socket#Socket(String, int, InetAddress, int)
      */
     public DelegatingSocket(

--- a/src/main/java/org/ice4j/socket/RtcpDemuxPacketFilter.java
+++ b/src/main/java/org/ice4j/socket/RtcpDemuxPacketFilter.java
@@ -36,18 +36,23 @@ public class RtcpDemuxPacketFilter
      *
      * RTP/RTCP packets are distinguished from other packets (such as STUN,
      * DTLS or ZRTP) by the value of their first byte. See
-     * {@link "http://tools.ietf.org/html/rfc5764#section-5.1.2"} and
-     * {@link "http://tools.ietf.org/html/rfc6189#section-5"}.
+     * <a href="http://tools.ietf.org/html/rfc5764#section-5.1.2">
+     * RFC5764, Section 5.1.2</a> and
+     * <a href="http://tools.ietf.org/html/rfc6189#section-5">RFC6189,
+     * Section 5</a>.
      *
      * RTCP packets are distinguished from RTP packet based on the second byte
      * (either Packet Type (RTCP) or M-bit and Payload Type (RTP). See
-     * {@link "http://tools.ietf.org/html/rfc5761#section-4"}
+     * <a href="http://tools.ietf.org/html/rfc5761#section-4">RFC5761, Section
+     * 4</a>
      *
      * We assume that RTCP packets have a packet type in [200, 211]. This means
      * that RTP packets with Payload Types in [72, 83] (which should not
      * appear, because these PTs are reserved or unassigned by IANA, see
-     * {@link "http://www.iana.org/assignments/rtp-parameters/rtp-parameters.xhtml"}
-     * ) with the M-bit set will be misidentified as RTCP packets.
+     * <a href="http://www.iana.org/assignments/rtp-parameters/rtp-parameters.xhtml">
+     * IANA RTP Parameters</a>) with the M-bit set will be misidentified as
+     * RTCP packets.
+     * 
      * Also, any RTCP packets with Packet Types not in [200, 211] will be
      * misidentified as RTP packets.
      *

--- a/src/main/java/org/ice4j/socket/SocketReceiveBuffer.java
+++ b/src/main/java/org/ice4j/socket/SocketReceiveBuffer.java
@@ -21,7 +21,7 @@ import java.net.*;
 import java.util.*;
 
 /**
- * Implements a list of <tt>DatagramPacket<tt>s received by a
+ * Implements a list of <tt>DatagramPacket</tt>s received by a
  * <tt>DatagramSocket</tt> or a <tt>Socket</tt>. The list enforces the
  * <tt>SO_RCVBUF</tt> option for the associated <tt>DatagramSocket</tt> or
  * <tt>Socket</tt>.

--- a/src/main/java/org/ice4j/socket/TCPInputStream.java
+++ b/src/main/java/org/ice4j/socket/TCPInputStream.java
@@ -85,7 +85,7 @@ public class TCPInputStream
     /**
      * Initializes a new <tt>TCPInputStream</tt>.
      *
-     * @param socket
+     * @param socket The inputStream for this instance.
      */
     public TCPInputStream(MultiplexingSocket socket)
     {

--- a/src/main/java/org/ice4j/stack/Connector.java
+++ b/src/main/java/org/ice4j/stack/Connector.java
@@ -84,6 +84,8 @@ class Connector
      * Creates a network access point.
      * @param socket the socket that this access point is supposed to use for
      * communication.
+     * @param remoteAddress the remote address of the socket of this
+     * {@link Connector} if it is a TCP socket, or null if it is UDP.
      * @param messageQueue the FIFO list where incoming messages should be queued
      * @param errorHandler the instance to notify when errors occur.
      */

--- a/src/main/java/org/ice4j/stack/NetAccessManager.java
+++ b/src/main/java/org/ice4j/stack/NetAccessManager.java
@@ -306,6 +306,9 @@ class NetAccessManager
      * has no effect.
      *
      * @param  socket   the socket that the access point should use.
+     * @param remoteAddress the remote address of the socket of the
+     * {@link Connector} to be created if it is a TCP socket, or null if it
+     * is UDP.
      */
     protected void addSocket(IceSocketWrapper socket,
                              TransportAddress remoteAddress)

--- a/src/main/java/org/ice4j/stack/StunStack.java
+++ b/src/main/java/org/ice4j/stack/StunStack.java
@@ -136,6 +136,9 @@ public class StunStack
      * specified socket and the specified remote address.
      *
      * @param sock The socket that the new access point should represent.
+     * @param remoteAddress the remote address of the socket of the
+     * {@link Connector} to be created if it is a TCP socket, or null if it
+     * is UDP.
      */
     public void addSocket(IceSocketWrapper sock, TransportAddress remoteAddress)
     {
@@ -368,6 +371,13 @@ public class StunStack
     /**
      * Initializes a new <tt>StunStack</tt> instance with given
      * peerUdpMessageEventHandler and channelDataEventHandler.
+     * 
+     * @param peerUdpMessageEventHandler the <tt>PeerUdpMessageEventHandler</tt>
+     *            that will handle incoming UDP messages which are not STUN
+     *            messages and ChannelData messages.
+     * @param channelDataEventHandler the <tt>ChannelDataEventHandler</tt> that
+     *            will handle incoming UDP messages which are ChannelData
+     *            messages.
      */
     public StunStack(PeerUdpMessageEventHandler peerUdpMessageEventHandler,
             ChannelDataEventHandler channelDataEventHandler)
@@ -630,9 +640,13 @@ public class StunStack
      * @param transactionID the ID that we'd like the new transaction to use
      * in case the application created it in order to use it for application
      * data correlation.
-     * @param originalWaitInterval
-     * @param maxWaitInterval
-     * @param maxRetransmissions
+     * @param originalWaitInterval The number of milliseconds to wait before
+     * the first retransmission of the request.
+     * @param maxWaitInterval The maximum wait interval. Once this interval is
+     * reached we should stop doubling its value.
+     * @param maxRetransmissions Maximum number of retransmissions. Once this
+     * number is reached and if no response is received after maxWaitInterval
+     * milliseconds the request is considered unanswered.
      * @return the <tt>TransactionID</tt> of the <tt>StunClientTransaction</tt>
      * that we used in order to send the request.
      *
@@ -1563,6 +1577,8 @@ public class StunStack
      * @param requestType the message type of Request.
      * @param errorCode the errorCode for Error Response object.
      * @param reasonPhrase the reasonPhrase for the Error Response object.
+     * @param unknownAttributes char[] array containing the ids of one or more
+     *            attributes that had not been recognized.
      * @return corresponding Error Response object.
      */
     public Response createCorrespondingErrorResponse(char requestType,

--- a/src/main/java/org/ice4j/util/PacketQueue.java
+++ b/src/main/java/org/ice4j/util/PacketQueue.java
@@ -22,12 +22,12 @@ import java.util.logging.*;
 /**
  * An abstract queue of packets. This is meant to eventually be able to be used
  * in the following classes (in ice4j and libjitsi) in place of their ad-hoc
- * queue implementations (which is the reason the class is parametrized):
- *     <br/> RTPConnectorOutputStream.Queue
- *     <br/> PushSourceStreamImpl#readQ
- *     <br/> OutputDataStreamImpl#writeQ
- *     <br/> SinglePortHarvester.MySocket#queue
- *     <br/> MultiplexingSocket#received (and the rest of Multiplex* classes).
+ * queue implementations (which is the reason the class is parameterized):
+ *     <br> RTPConnectorOutputStream.Queue
+ *     <br> PushSourceStreamImpl#readQ
+ *     <br> OutputDataStreamImpl#writeQ
+ *     <br> SinglePortHarvester.MySocket#queue
+ *     <br> MultiplexingSocket#received (and the rest of Multiplex* classes).
  *
  * @author Boris Grozev
  */

--- a/src/main/java/org/ice4j/util/QueueStatistics.java
+++ b/src/main/java/org/ice4j/util/QueueStatistics.java
@@ -58,7 +58,9 @@ public class QueueStatistics
 
     /**
      * Initializes a new {@link QueueStatistics} instance.
-     * @param id
+     * 
+     * @param id Identifier to distinguish the log output of multiple
+     *            {@link QueueStatistics} instances.
      */
     public QueueStatistics(String id)
     {


### PR DESCRIPTION
This now satisfies Java 8's Javadoc compiler with it's default options.