### PR TITLE
Ensure tieBreaker is positive

### DIFF
--- a/src/main/java/org/ice4j/ice/Agent.java
+++ b/src/main/java/org/ice4j/ice/Agent.java
@@ -315,7 +315,7 @@ public class Agent
                     new BigInteger(128, random).toString(32),
                     /* min */ 22, /* max */ 256);
 
-        tieBreaker = Math.abs(random.nextLong());
+        tieBreaker = random.nextLong() & 0x7FFFFFFFFFFFFFFFL;
         nominator = new DefaultNominator(this);
     }
 


### PR DESCRIPTION
Math.abs(Integer.MIN_VALUE) == Integer.MIN_VALUE
http://findbugs.sourceforge.net/bugDescriptions.html#RV_ABSOLUTE_VALUE_OF_RANDOM_INT

Signed-off-by: Etienne CHAMPETIER <champetier.etienne@gmail.com>