### PR TITLE
 Fixes a failure to close a Socket instance. 

### DIFF
--- a/src/main/java/org/ice4j/ice/harvest/TcpHarvester.java
+++ b/src/main/java/org/ice4j/ice/harvest/TcpHarvester.java
@@ -1098,8 +1098,8 @@ public class TcpHarvester
         }
 
         /**
-         * Adds the channels from {@link #newChannels} to {@link #channels} and
-         * registers them in {@link #readSelector}.
+         * Registers the channels from {@link #newChannels} in
+         * {@link #readSelector}.
          */
         private void checkForNewChannels()
         {
@@ -1126,8 +1126,11 @@ public class TcpHarvester
         }
 
         /**
-         * Checks {@link #channels} for channels which have been added over
-         * {@link #READ_TIMEOUT} milliseconds ago and closes them.
+         * Closes any inactive channels registered with {@link #readSelector}.
+         * A channel is considered inactive if it hasn't been available for
+         * reading for
+         * {@link MuxServerSocketChannelFactory#SOCKET_CHANNEL_READ_TIMEOUT}
+         * milliseconds.
          */
         private void cleanup()
         {

--- a/src/main/java/org/ice4j/ice/harvest/TcpHarvester.java
+++ b/src/main/java/org/ice4j/ice/harvest/TcpHarvester.java
@@ -1226,10 +1226,8 @@ public class TcpHarvester
             if (!IceProcessingState.WAITING.equals(state)
                     && !IceProcessingState.RUNNING.equals(state))
             {
-                logger.info(
-                        "Not adding a socket to an ICE agent with state "
-                            + state);
-                return;
+                throw new IllegalStateException(
+                    "The associated Agent is in state " + state);
             }
 
             // Socket to add to the candidate
@@ -1433,19 +1431,11 @@ public class TcpHarvester
                     }
                 }
             }
-            catch (IOException ioe)
+            catch (IOException | StunException | IllegalStateException e)
             {
                 logger.info(
                         "Failed to handle TCP socket "
-                            + channel.channel.socket() + ": " + ioe);
-                key.cancel();
-                closeNoExceptions(channel.channel);
-            }
-            catch (StunException se)
-            {
-                logger.info(
-                        "Failed to handle TCP socket "
-                            + channel.channel.socket() + ": " + se);
+                            + channel.channel.socket() + ": " + e.getMessage());
                 key.cancel();
                 closeNoExceptions(channel.channel);
             }


### PR DESCRIPTION
Makes sure that Socket instances which are discarded because
they are only added after the corresponding ICE Agent has
moved away from the WAITING or RUNNING state are closed. This
prevents a file descriptor leak, since Socket instances which are
not closed (even after they are garbage collected) leave behind
sockets in state CLOSE_WAIT.