### PR TITLE
Harvesting

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,0 +1,79 @@
+# General
+This file describes some of the java properties which ```ice4j``` uses
+to configure itself.
+
+## Interfaces and IP addresses
+
+### *org.ice4j.ice.harvest.ALLOWED_INTERFACES*
+Default: all interfaces are allowed.
+
+This property can be used to specify a ";"-separated list of interfaces which are
+allowed to be used for candidate allocations. If not specified, all interfaces are
+considered allowed, unless they are explicitly blocked (see below).
+
+### *org.ice4j.ice.harvest.BLOCKED_INTERFACES*
+Default: no interfaces are blocked.
+
+This property can be used to specify a ";"-separated list of interfaces which are
+not allowed to be used for candidate allocations. 
+
+### *org.ice4j.ice.harvest.ALLOWED_ADDRESSES*
+Default: all addresses are allowed.
+
+This property can be used to specify a ";"-separated list of IP addresses which
+are allowed to be used for candidate allocations. If not specified, all addresses
+are considered allowed, unless they are explicitly blocked (see below).
+
+### *org.ice4j.ice.harvest.BLOCKED_ADDRESSES*
+Default: no addresses are blocked.
+
+This property can be used to specify a ";"-separated list of IP addresses which
+are not allowed to be used for candidate allocations. 
+
+### *org.ice4j.ipv6.DISABLED*
+Type: boolean
+
+Default: false
+
+This property can be used to disable binding on IPv6 addresses.
+
+
+## Mapping harvesters
+Ice4j uses the concept of "mapping harvesters" to handle known IP address
+mappings. A set of mapping harvesters is configured once when the library
+initializes, and each of them contains a pair of IP addresses (local and public).
+
+When an ICE Agent gathers candidates, it uses the set of mapping harvesters
+to obtain ```srflx``` candidates without the use to e.g. a STUN server dynamically.
+
+Mapping harvesters preserve the port number of the original candidate, so they should
+only be used when port numbers are preserved.
+
+Ice4j implements three types of mapping harvesters: one with a pre-configured pair of 
+addresses, one two which discover addresses dynamically using the AWS API and STUN.
+
+
+### *org.ice4j.ice.harvest.NAT_HARVESTER_LOCAL_ADDRESS*
+### *org.ice4j.ice.harvest.NAT_HARVESTER_PUBLIC_ADDRESS*
+Default: none
+
+Configures the addresses of the pre-configured mapping harvester.
+
+### *org.ice4j.ice.harvest.DISABLE_AWS_HARVESTER*
+Default: false
+
+Explicitly disables the AWS mapping harvester. By default the harvester
+is enabled if ice4j detects that it is running in the AWS network.
+
+### *org.ice4j.ice.harvest.FORCE_AWS_HARVESTER*
+Default: false
+
+Force the use of the AWS mapping harvester, even if ice4j did not detect
+that it is running in the AWS network.
+
+### *org.ice4j.ice.harvest.STUN_MAPPING_HARVESTER_ADDRESSES*
+Default: none
+
+A comma-separated list of STUN server addresses to use for mapping harvesters.
+Each STUN server address is an ip_address:port pair.
+Example: ```stun1.example.com:12345,stun2.example.com:23456```

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <artifactId>ice4j</artifactId>
-  <version>1.1-SNAPSHOT</version>
+  <version>2.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>ice4j</name>

--- a/src/main/java/org/ice4j/ice/Agent.java
+++ b/src/main/java/org/ice4j/ice/Agent.java
@@ -367,6 +367,12 @@ public class Agent
 
         tieBreaker = random.nextLong() & 0x7FFFFFFFFFFFFFFFL;
         nominator = new DefaultNominator(this);
+
+        for (MappingCandidateHarvester harvester
+                    : MappingCandidateHarvesters.getHarvesters())
+        {
+            addCandidateHarvester(harvester);
+        }
     }
 
     /**

--- a/src/main/java/org/ice4j/ice/harvest/AbstractCandidateHarvester.java
+++ b/src/main/java/org/ice4j/ice/harvest/AbstractCandidateHarvester.java
@@ -35,6 +35,7 @@ public abstract class AbstractCandidateHarvester
     /**
      * {@inheritDoc}
      */
+    @Override
     public HarvestStatistics getHarvestStatistics()
     {
         return harvestStatistics;
@@ -43,6 +44,7 @@ public abstract class AbstractCandidateHarvester
     /**
      * {@inheritDoc}
      */
+    @Override
     public boolean isHostHarvester()
     {
         return false;

--- a/src/main/java/org/ice4j/ice/harvest/AbstractUdpListener.java
+++ b/src/main/java/org/ice4j/ice/harvest/AbstractUdpListener.java
@@ -85,6 +85,21 @@ public abstract class AbstractUdpListener
     public static List<TransportAddress> getAllowedAddresses(int port)
     {
         List<TransportAddress> addresses = new LinkedList<>();
+        for (InetAddress address : getAllowedInetAddresses())
+        {
+            addresses.add(new TransportAddress(address, port, Transport.UDP));
+        }
+
+        return addresses;
+    }
+
+    /**
+     * @return the list of all local IP addresses from all allowed network
+     * interfaces, which are allowed addresses.
+     */
+    public static List<InetAddress> getAllowedInetAddresses()
+    {
+        List<InetAddress> addresses = new LinkedList<>();
         boolean isIPv6Disabled = StackProperties.getBoolean(
                 StackProperties.DISABLE_IPv6,
                 false);
@@ -120,8 +135,7 @@ public abstract class AbstractUdpListener
                             && address.isLinkLocalAddress())
                         continue;
 
-                    addresses.add(
-                        new TransportAddress(address, port, Transport.UDP));
+                    addresses.add(address);
                 }
             }
         }

--- a/src/main/java/org/ice4j/ice/harvest/AbstractUdpListener.java
+++ b/src/main/java/org/ice4j/ice/harvest/AbstractUdpListener.java
@@ -19,10 +19,7 @@ package org.ice4j.ice.harvest;
 
 import org.ice4j.*;
 import org.ice4j.attribute.*;
-import org.ice4j.ice.*;
 import org.ice4j.message.*;
-import org.ice4j.socket.*;
-import org.ice4j.stack.*;
 import org.ice4j.util.*;
 
 import java.io.*;
@@ -85,63 +82,10 @@ public abstract class AbstractUdpListener
     public static List<TransportAddress> getAllowedAddresses(int port)
     {
         List<TransportAddress> addresses = new LinkedList<>();
-        for (InetAddress address : getAllowedInetAddresses())
+        for (InetAddress address
+                : HostCandidateHarvester.getAllAllowedAddresses())
         {
             addresses.add(new TransportAddress(address, port, Transport.UDP));
-        }
-
-        return addresses;
-    }
-
-    /**
-     * @return the list of all local IP addresses from all allowed network
-     * interfaces, which are allowed addresses.
-     */
-    public static List<InetAddress> getAllowedInetAddresses()
-    {
-        List<InetAddress> addresses = new LinkedList<>();
-        boolean isIPv6Disabled = StackProperties.getBoolean(
-                StackProperties.DISABLE_IPv6,
-                false);
-        boolean isIPv6LinkLocalDisabled = StackProperties.getBoolean(
-                StackProperties.DISABLE_LINK_LOCAL_ADDRESSES,
-                false);
-
-        try
-        {
-            for (NetworkInterface iface
-                    : Collections.list(NetworkInterface.getNetworkInterfaces()))
-            {
-                if (NetworkUtils.isInterfaceLoopback(iface)
-                        || !NetworkUtils.isInterfaceUp(iface)
-                        || !HostCandidateHarvester.isInterfaceAllowed(iface))
-                {
-                    continue;
-                }
-
-                Enumeration<InetAddress> ifaceAddresses
-                        = iface.getInetAddresses();
-                while (ifaceAddresses.hasMoreElements())
-                {
-                    InetAddress address = ifaceAddresses.nextElement();
-
-                    if (!HostCandidateHarvester.isAddressAllowed(address))
-                        continue;
-
-                    if (isIPv6Disabled && address instanceof Inet6Address)
-                        continue;
-                    if (isIPv6LinkLocalDisabled
-                            && address instanceof Inet6Address
-                            && address.isLinkLocalAddress())
-                        continue;
-
-                    addresses.add(address);
-                }
-            }
-        }
-        catch (SocketException se)
-        {
-            logger.info("Failed to get network interfaces: " + se);
         }
 
         return addresses;

--- a/src/main/java/org/ice4j/ice/harvest/AwsCandidateHarvester.java
+++ b/src/main/java/org/ice4j/ice/harvest/AwsCandidateHarvester.java
@@ -83,7 +83,7 @@ public class AwsCandidateHarvester
      */
     public AwsCandidateHarvester()
     {
-        super(null, null);
+        super();
     }
 
     /**

--- a/src/main/java/org/ice4j/ice/harvest/AwsCandidateHarvester.java
+++ b/src/main/java/org/ice4j/ice/harvest/AwsCandidateHarvester.java
@@ -130,6 +130,7 @@ public class AwsCandidateHarvester
      * Returns the public (mask) address, or null.
      * @return the public (mask) address, or null.
      */
+    @Override
     public TransportAddress getMask()
     {
         if (smellsLikeAnEC2())
@@ -144,6 +145,7 @@ public class AwsCandidateHarvester
      * Returns the local (face) address, or null.
      * @return the local (face) address, or null.
      */
+    @Override
     public TransportAddress getFace()
     {
         if (smellsLikeAnEC2())

--- a/src/main/java/org/ice4j/ice/harvest/HostCandidateHarvester.java
+++ b/src/main/java/org/ice4j/ice/harvest/HostCandidateHarvester.java
@@ -708,18 +708,12 @@ public class HostCandidateHarvester
      * @throws java.lang.IllegalStateException if there were errors during host
      * candidate interface filters initialization.
      */
-    public static void initializeInterfaceFilters()
+    public static synchronized void initializeInterfaceFilters()
     {
-        synchronized (HostCandidateHarvester.class)
-        {
-            // We want this method to run only once.
-            if (interfaceFiltersInitialized)
-                return;
-
-            interfaceFiltersInitialized = true;
-
-            // Should we hold this lock until we are done modifying the fields?
-        }
+        // We want this method to run only once.
+        if (interfaceFiltersInitialized)
+            return;
+        interfaceFiltersInitialized = true;
 
         // Initialize the allowed interfaces array.
         allowedInterfaces = StackProperties.getStringArray(

--- a/src/main/java/org/ice4j/ice/harvest/MappingCandidateHarvester.java
+++ b/src/main/java/org/ice4j/ice/harvest/MappingCandidateHarvester.java
@@ -83,6 +83,7 @@ public class MappingCandidateHarvester
      * @return  the <tt>LocalCandidate</tt>s gathered by this
      * <tt>CandidateHarvester</tt> or <tt>null</tt> if no mask is specified.
      */
+    @Override
     public Collection<LocalCandidate> harvest(Component component)
     {
         TransportAddress mask = getMask();

--- a/src/main/java/org/ice4j/ice/harvest/MappingCandidateHarvester.java
+++ b/src/main/java/org/ice4j/ice/harvest/MappingCandidateHarvester.java
@@ -100,14 +100,12 @@ public class MappingCandidateHarvester
         if (face == null || mask == null)
         {
             logger.warning("Harvester not configured: face=" + face
-                           + ", mask="+mask);
+                           + ", mask=" + mask);
             return null;
         }
 
-        /*
-         * Report the LocalCandidates gathered by this CandidateHarvester so
-         * that the harvest is sure to be considered successful.
-         */
+         // Report the LocalCandidates gathered by this CandidateHarvester so
+         // that the harvest is sure to be considered successful.
         Collection<LocalCandidate> candidates = new HashSet<>();
 
         for (Candidate<?> cand : component.getLocalCandidates())
@@ -163,5 +161,19 @@ public class MappingCandidateHarvester
     public TransportAddress getFace()
     {
         return face;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString()
+    {
+        TransportAddress face = getFace();
+        TransportAddress mask = getMask();
+        return
+            this.getClass().getName()
+                    + ", face=" + (face == null ? "null" : face.getAddress())
+                    + ", mask=" + (mask == null ? "null" : mask.getAddress());
     }
 }

--- a/src/main/java/org/ice4j/ice/harvest/MappingCandidateHarvester.java
+++ b/src/main/java/org/ice4j/ice/harvest/MappingCandidateHarvester.java
@@ -70,8 +70,17 @@ public class MappingCandidateHarvester
     public MappingCandidateHarvester(TransportAddress mask,
                                      TransportAddress face)
     {
-        this.mask = mask;
-        this.face = face;
+        this.mask = Objects.requireNonNull(mask);
+        this.face = Objects.requireNonNull(face);
+    }
+
+    /**
+     * Initializes a {@link MappingCandidateHarvester} instance without
+     * specified addresses (only useful in subclasses which override
+     * {@link #getMask()} and {@link #getFace()}).
+     */
+    protected MappingCandidateHarvester()
+    {
     }
 
     /**

--- a/src/main/java/org/ice4j/ice/harvest/MappingCandidateHarvester.java
+++ b/src/main/java/org/ice4j/ice/harvest/MappingCandidateHarvester.java
@@ -21,6 +21,7 @@ import org.ice4j.*;
 import org.ice4j.ice.*;
 
 import java.util.*;
+import java.util.logging.*;
 
 /**
  * Uses a list of addresses as a predefined static mask in order to generate
@@ -43,6 +44,13 @@ import java.util.*;
 public class MappingCandidateHarvester
     extends AbstractCandidateHarvester
 {
+    /**
+     * The <tt>Logger</tt> used by the <tt>StunCandidateHarvester</tt> class and
+     * its instances for logging output.
+     */
+    private static final Logger logger
+        = Logger.getLogger(StunCandidateHarvester.class.getName());
+
     /**
      * The addresses that we will use as a mask
      */
@@ -77,8 +85,14 @@ public class MappingCandidateHarvester
      */
     public Collection<LocalCandidate> harvest(Component component)
     {
-        if (getMask() == null || getFace() == null)
+        TransportAddress mask = getMask();
+        TransportAddress face = getFace();
+        if (face == null || mask == null)
+        {
+            logger.warning("Harvester not configured: face=" + face
+                           + ", mask="+mask);
             return null;
+        }
 
         /*
          * Report the LocalCandidates gathered by this CandidateHarvester so
@@ -90,15 +104,15 @@ public class MappingCandidateHarvester
         {
             if (!(cand instanceof HostCandidate)
                 || !cand.getTransportAddress().getHostAddress()
-                            .equals(getFace().getHostAddress())
-                || cand.getTransport() != getFace().getTransport())
+                            .equals(face.getHostAddress())
+                || cand.getTransport() != face.getTransport())
             {
                 continue;
             }
 
             HostCandidate hostCandidate = (HostCandidate) cand;
             TransportAddress mappedAddress = new TransportAddress(
-                getMask().getHostAddress(),
+                mask.getHostAddress(),
                 hostCandidate.getHostAddress().getPort(),
                 hostCandidate.getHostAddress().getTransport());
 
@@ -129,7 +143,7 @@ public class MappingCandidateHarvester
      */
     public TransportAddress getMask()
     {
-        return this.mask;
+        return mask;
     }
 
     /**
@@ -138,6 +152,6 @@ public class MappingCandidateHarvester
      */
     public TransportAddress getFace()
     {
-        return this.face;
+        return face;
     }
 }

--- a/src/main/java/org/ice4j/ice/harvest/MappingCandidateHarvesters.java
+++ b/src/main/java/org/ice4j/ice/harvest/MappingCandidateHarvesters.java
@@ -187,7 +187,8 @@ public class MappingCandidateHarvesters
             logger.info("Using " + harvester);
         }
         logger.info("Initialized mapping harvesters (delay="
-                        + (System.currentTimeMillis() - start) + "ms).");
+                        + (System.currentTimeMillis() - start) + "ms). "
+                        + " stunDiscoveryFailed=" + stunDiscoveryFailed);
     }
 
     /**

--- a/src/main/java/org/ice4j/ice/harvest/MappingCandidateHarvesters.java
+++ b/src/main/java/org/ice4j/ice/harvest/MappingCandidateHarvesters.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright @ 2015-2016 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ice4j.ice.harvest;
+
+import org.ice4j.*;
+
+import java.net.*;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.logging.*;
+
+/**
+ * Manages a static list of {@link MappingCandidateHarvester} instances, created
+ * according to configuration provided as system properties.
+ *
+ * The instances in the set are safe to use by any {@code Agent}s.
+ *
+ * @author Damian Minkov
+ * @author Boris Grozev
+ */
+public class MappingCandidateHarvesters
+{
+    /**
+     * The {@link Logger} used by the {@link MappingCandidateHarvesters}
+     * class for logging output.
+     */
+    private static final Logger logger
+        = Logger.getLogger(MappingCandidateHarvesters.class.getName());
+
+    /**
+     * The name of the property that specifies the local address, if any, for
+     * the pre-configured NAT harvester.
+     */
+    public static final String NAT_HARVESTER_LOCAL_ADDRESS_PNAME
+        = "org.ice4j.ice.harvest.NAT_HARVESTER_LOCAL_ADDRESS";
+
+    /**
+     * The name of the property that specifies the public address, if any, for
+     * the pre-configured NAT harvester.
+     */
+    public static final String NAT_HARVESTER_PUBLIC_ADDRESS_PNAME
+        = "org.ice4j.ice.harvest.NAT_HARVESTER_PUBLIC_ADDRESS";
+
+    /**
+     * The name of the property used to disable the AWS harvester.
+     */
+    public static final String DISABLE_AWS_HARVESTER_PNAME
+        = "org.ice4j.ice.harvest.DISABLE_AWS_HARVESTER";
+
+    /**
+     * The name of the property which forces the use of the AWS harvester.
+     */
+    public static final String FORCE_AWS_HARVESTER_PNAME
+        = "org.ice4j.ice.harvest.FORCE_AWS_HARVESTER";
+
+    /**
+     * The name of the property which contains the addresses of the STUN servers
+     * to use for the STUN mapping harvester. The property should contain a
+     * comma-separated list of addresses (pairs of IP address and port,
+     * separated by a colon). Example:
+     * {@code stun1.example.com:12345,stun2.example.com:23456}
+     */
+    public static final String STUN_MAPPING_HARVESTER_ADDRESSES_PNAME
+        = "org.ice4j.ice.harvest.STUN_MAPPING_HARVESTER_ADDRESSES";
+
+    /**
+     * Whether {@link #harvesters} has been initialized.
+     */
+    private static boolean initialized = false;
+
+    /**
+     * The list of already configured harvesters.
+     */
+    private static MappingCandidateHarvester[] harvesters;
+
+    /**
+     * Whether the discovery of a public address via STUN has failed.
+     * It is considered failed if the configuration included at least one STUN
+     * server, but we failed to receive at least one valid response.
+     * Note that this defaults to false and is only raised after we are certain
+     * we failed (i.e. after our STUN transactions timeout).
+     */
+    public static boolean stunDiscoveryFailed = false;
+
+    /**
+     * @return the list of configured harvesters.
+     */
+    public static MappingCandidateHarvester[] getHarvesters()
+    {
+        initialize();
+        return harvesters;
+    }
+
+    /**
+     * Initializes {@link #harvesters}.
+     * First it reads the configuration and instantiates harvesters accordingly,
+     * waiting for their initialization (which may include network communication
+     * and thus take a long time). Then it removes harvesters which failed to
+     * initialize properly and remove any harvesters with duplicate addresses.
+     *
+     * Three types of mapping harvesters are supported: NAT (with
+     * pre-configured addresses), AWS and STUN.
+     */
+    public static synchronized void initialize()
+    {
+        if (initialized)
+            return;
+        initialized = true;
+
+        long start = System.currentTimeMillis();
+        List<MappingCandidateHarvester> harvesterList = new LinkedList<>();
+
+
+        // Pre-configured NAT harvester.
+        String localAddressStr
+            = StackProperties.getString(NAT_HARVESTER_LOCAL_ADDRESS_PNAME);
+        String publicAddressStr
+            = StackProperties.getString(NAT_HARVESTER_PUBLIC_ADDRESS_PNAME);
+
+        if (localAddressStr != null && publicAddressStr != null)
+        {
+            // the port number is unused, 9 is for "discard"
+            TransportAddress localAddress
+                = new TransportAddress(localAddressStr, 9, Transport.UDP);
+            TransportAddress publicAddress
+                = new TransportAddress(publicAddressStr, 9, Transport.UDP);
+
+            harvesterList.add(
+                new MappingCandidateHarvester(publicAddress, localAddress));
+        }
+
+        // AWS harvester
+        boolean disableAwsHarvester
+            = StackProperties.getBoolean(DISABLE_AWS_HARVESTER_PNAME, false);
+        boolean forceAwsHarvester
+            = StackProperties.getBoolean(FORCE_AWS_HARVESTER_PNAME, false);
+
+        if (logger.isLoggable(Level.FINE))
+        {
+            logger.fine("AWS configuration: disable=" + disableAwsHarvester
+                        + "; force=" + forceAwsHarvester);
+        }
+
+        if (!disableAwsHarvester &&
+            (forceAwsHarvester || AwsCandidateHarvester.smellsLikeAnEC2()))
+        {
+            harvesterList.add(new AwsCandidateHarvester());
+        }
+
+        // STUN harvesters
+        String stunServers
+            = StackProperties.getString(STUN_MAPPING_HARVESTER_ADDRESSES_PNAME);
+        if (stunServers != null && !stunServers.isEmpty())
+        {
+            // Create STUN harvesters (and wait for all of their discovery to
+            // finish).
+            List<StunMappingCandidateHarvester> stunHarvesters
+                = createStunHarvesters(stunServers.split(","));
+
+            // We have STUN servers configured, so flag the failure if none of
+            // them were able to discover an address.
+            stunDiscoveryFailed = stunHarvesters.isEmpty();
+
+            harvesterList.addAll(stunHarvesters);
+        }
+
+        harvesterList = prune(harvesterList);
+        harvesters
+            = harvesterList.toArray(
+                    new MappingCandidateHarvester[harvesterList.size()]);
+
+        for (MappingCandidateHarvester harvester : harvesters)
+        {
+            logger.info("Using " + harvester);
+        }
+        logger.info("Initialized mapping harvesters (delay="
+                        + (System.currentTimeMillis() - start) + "ms).");
+    }
+
+    /**
+     * Prunes a list of mapping harvesters, removing the ones without valid
+     * addresses and those with duplicate addresses.
+     * @param harvesters the list of harvesters.
+     * @return the pruned list.
+     */
+    private static List<MappingCandidateHarvester> prune(
+        List<MappingCandidateHarvester> harvesters)
+    {
+        List<MappingCandidateHarvester> pruned = new LinkedList<>();
+        for (MappingCandidateHarvester harvester : harvesters)
+        {
+            maybeAdd(harvester, pruned);
+        }
+        return pruned;
+    }
+
+    /**
+     * Adds {@code harvester} to {@code harvesters}, if it has valid addresses
+     * and {@code harvesters} doesn't already contain a harvester with the same
+     * addresses.
+     * @param harvester the harvester to add.
+     * @param harvesters the list to add to.
+     */
+    private static void maybeAdd(
+        MappingCandidateHarvester harvester,
+        List<MappingCandidateHarvester> harvesters)
+    {
+        TransportAddress face = harvester.getFace();
+        TransportAddress mask = harvester.getMask();
+        if (face == null || mask == null || face.equals(mask))
+        {
+            logger.info("Discarding a mapping harvester: " + harvester);
+            return;
+        }
+
+        for (MappingCandidateHarvester h : harvesters)
+        {
+            if (face.getAddress().equals(h.getFace().getAddress()) && mask.getAddress().equals(h.getMask().getAddress()))
+            {
+                logger.info("Discarding a mapping harvester with duplicate "
+                            + "addresses: " + harvester + ". Kept: " + h);
+                return;
+            }
+        }
+
+        harvesters.add(harvester);
+    }
+
+    /**
+     * Creates STUN mapping harvesters for each of the given STUN servers, and
+     * waits for address discovery to finish for all of them.
+     * @param stunServers an array of STUN server addresses (ip_address:port
+     * pairs).
+     * @return  the list of those who were successful in discovering an address.
+     */
+    private static List<StunMappingCandidateHarvester> createStunHarvesters(
+            String[] stunServers)
+    {
+        List<StunMappingCandidateHarvester> stunHarvesters = new LinkedList<>();
+
+        if (stunServers == null || stunServers.length == 0)
+        {
+            logger.severe("No STUN servers configured.");
+            return stunHarvesters;
+        }
+
+        List<Callable<StunMappingCandidateHarvester>> tasks = new LinkedList<>();
+
+        // Create a StunMappingCandidateHarvester for each local:remote address
+        // pair.
+        List<InetAddress> localAddresses
+            = HostCandidateHarvester.getAllAllowedAddresses();
+        for (String stunServer : stunServers)
+        {
+            String[] addressAndPort = stunServer.split(":");
+            if (addressAndPort.length < 2)
+            {
+                logger.severe("Failed to parse STUN server address: "
+                                  + stunServer);
+                continue;
+            }
+            int port;
+            try
+            {
+                port = Integer.parseInt(addressAndPort[1]);
+            }
+            catch (NumberFormatException nfe)
+            {
+                logger.severe("Invalid STUN server port: " + addressAndPort[1]);
+                continue;
+            }
+
+            TransportAddress remoteAddress
+                = new TransportAddress(
+                addressAndPort[0],
+                port,
+                Transport.UDP);
+
+            for (InetAddress localInetAddress : localAddresses)
+            {
+                if (localInetAddress instanceof Inet6Address)
+                {
+                    // This is disabled, because it is broken for an unknown
+                    // reason and it is not currently needed.
+                    continue;
+                }
+
+                TransportAddress localAddress
+                    = new TransportAddress(localInetAddress, 0, Transport.UDP);
+
+                final StunMappingCandidateHarvester stunHarvester
+                    = new StunMappingCandidateHarvester(
+                            localAddress,
+                            remoteAddress);
+
+                Callable<StunMappingCandidateHarvester> task
+                    = new Callable<StunMappingCandidateHarvester>()
+                {
+                    @Override
+                    public StunMappingCandidateHarvester call()
+                        throws Exception
+                    {
+                        stunHarvester.discover();
+                        return stunHarvester;
+                    }
+                };
+                tasks.add(task);
+            }
+        }
+
+        // Now run discover() on all created harvesters in parallel and pick
+        // the ones which succeeded.
+        ExecutorService es = Executors.newFixedThreadPool(tasks.size());
+
+        List<Future<StunMappingCandidateHarvester>> futures;
+        try
+        {
+            futures = es.invokeAll(tasks);
+        }
+        catch (InterruptedException ie)
+        {
+            Thread.currentThread().interrupt();
+            return stunHarvesters;
+        }
+
+        for (Future<StunMappingCandidateHarvester> future : futures)
+        {
+            try
+            {
+                StunMappingCandidateHarvester harvester = future.get();
+
+                // The STUN server replied successfully.
+                if (harvester.getMask() != null)
+                {
+                    stunHarvesters.add(harvester);
+                }
+            }
+            catch (ExecutionException ee)
+            {
+                // The harvester failed for some reason, discard it.
+            }
+            catch(InterruptedException ie)
+            {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(ie);
+            }
+        }
+
+        return stunHarvesters;
+    }
+
+    /**
+     * Prevent instance creation.
+     */
+    private MappingCandidateHarvesters()
+    {
+    }
+}

--- a/src/main/java/org/ice4j/ice/harvest/StunCandidateHarvester.java
+++ b/src/main/java/org/ice4j/ice/harvest/StunCandidateHarvester.java
@@ -237,8 +237,11 @@ public class StunCandidateHarvester
     @Override
     public Collection<LocalCandidate> harvest(Component component)
     {
-        logger.fine("starting " + component.toShortString()
-            + " harvest for: " + toString() );
+        if (logger.isLoggable(Level.FINE))
+        {
+            logger.fine("starting " + component.toShortString()
+                            + " harvest for: " + toString());
+        }
         stunStack = component.getParentStream().getParentAgent().getStunStack();
 
         for (Candidate<?> cand : component.getLocalCandidates())

--- a/src/main/java/org/ice4j/ice/harvest/StunCandidateHarvester.java
+++ b/src/main/java/org/ice4j/ice/harvest/StunCandidateHarvester.java
@@ -234,6 +234,7 @@ public class StunCandidateHarvester
      * @return  the <tt>LocalCandidate</tt>s gathered by this
      * <tt>CandidateHarvester</tt>
      */
+    @Override
     public Collection<LocalCandidate> harvest(Component component)
     {
         logger.fine("starting " + component.toShortString()

--- a/src/main/java/org/ice4j/ice/harvest/StunMappingCandidateHarvester.java
+++ b/src/main/java/org/ice4j/ice/harvest/StunMappingCandidateHarvester.java
@@ -18,15 +18,18 @@
 package org.ice4j.ice.harvest;
 
 import org.ice4j.*;
-import org.ice4j.ice.*;
+import org.ice4j.socket.*;
+import org.ice4j.stunclient.*;
 
+import java.net.*;
 import java.util.logging.*;
 
 /**
- * A MappingCandidateHarvester which use a list of pre-configured stun servers
- * to discover its public ip address.
+ * A {@link MappingCandidateHarvester} which uses a STUN servers to discover
+ * its public IP address.
  *
  * @author Damian Minkov
+ * @author Boris Grozev
  */
 public class StunMappingCandidateHarvester
     extends MappingCandidateHarvester
@@ -39,131 +42,55 @@ public class StunMappingCandidateHarvester
         = Logger.getLogger(StunMappingCandidateHarvester.class.getName());
 
     /**
-     * The addresses that we will use as a mask
-     */
-    private static TransportAddress mask;
-
-    /**
-     * The addresses that we will be masking
-     */
-    private static TransportAddress face;
-
-    /**
-     * Whether we have already checked and found the mapping addresses.
-     */
-    private static boolean addressChecked = false;
-
-    /**
      * The list of servers we will use to discover our public address.
      */
-    private static String[] stunServers;
+    private TransportAddress stunServerAddress;
 
     /**
-     * Creates a mapping harvester with the specified <tt>mask</tt>
-     * @param servers list of stun servers in the form address:port
+     * Initializes a new {@link StunMappingCandidateHarvester} instance with
+     * a given local address and a STUN server address. Note that the actual
+     * discovery of the public address needs to be initiated to a separate call
+     * to {@link #discover()}.
+     * @param localAddress The local address.
+     * @param stunServerAddress The address of the STUN server.
      */
-    public StunMappingCandidateHarvester(String[] servers)
+    public StunMappingCandidateHarvester(
+            TransportAddress localAddress,
+            TransportAddress stunServerAddress)
     {
-        super(null, null);
-
-        StunMappingCandidateHarvester.stunServers = servers;
-
-        // we have the list of addresses lets, try discovering
-        obtainAddresses();
+        face = localAddress;
+        this.stunServerAddress = stunServerAddress;
     }
 
     /**
-     * Creates a mapping harvester with the specified <tt>mask</tt>
+     * Attempts to discover the the public address (mask) via the STUN server.
+     * Note that this will block until we either receive a response from the
+     * STUN server, or a timeout occurs.
      */
-    public StunMappingCandidateHarvester()
+    public void discover()
     {
-        super(null, null);
-    }
-
-    /**
-     * Uses the pre-configured list of stun servers to discover our public
-     * address. Uses the first successful one and ignore the rest.
-     * Learn the private (face) and public (mask) addresses of this instance.
-     */
-    private static synchronized void obtainAddresses()
-    {
-        if (addressChecked)
-            return;
-        addressChecked = true;
-
         try
         {
-            for (String server : stunServers)
+            SimpleAddressDetector sad
+                = new SimpleAddressDetector(stunServerAddress);
+            sad.start();
+
+            IceSocketWrapper localSocket
+                = new IceUdpSocketWrapper(new DatagramSocket(face));
+
+            mask = sad.getMappingFor(localSocket);
+            if (mask != null)
             {
-                String[] addressAndPort = server.split(":");
-
-                StunCandidateHarvester stunHarv = new StunCandidateHarvester(
-                    new TransportAddress(
-                            addressAndPort[0],
-                            Integer.parseInt(addressAndPort[1]),
-                            Transport.UDP));
-
-                Agent agent = new Agent();
-                agent.setTrickling(false);
-                agent.addCandidateHarvester(stunHarv);
-
-                IceMediaStream stream = agent.createMediaStream("audio");
-                // local ports does not matter, just to be something
-                // out of the default used range
-                agent.createComponent(
-                    stream, Transport.UDP, 32020, 32020, 32020 + 100);
-
-                IceMediaStream iceMediaStream = agent.getStreams().get(0);
-                TransportAddress addr = iceMediaStream
-                    .getComponent(Component.RTP).getDefaultCandidate()
-                    .getTransportAddress();
-                mask = addr;
-
-                Candidate<?> candidate =
-                    iceMediaStream.getComponents().get(0).getDefaultCandidate();
-                face = candidate.getHostAddress();
-
-                agent.free();
-
-                if (mask != null && face != null)
-                    break;
+                logger.info("Discovered public address " + mask
+                                + " from STUN server " + stunServerAddress
+                                + " using local address " + face);
             }
-
-            logger.info("Detected through stun local IP: " + face);
-            logger.info("Detected through stun public IP: " + mask);
-
         }
         catch (Exception exc)
         {
-            //whatever happens, we just log and fail
+            //whatever happens, we just log
             logger.log(Level.INFO, "We failed to obtain addresses "
                 + "for the following reason: ", exc);
         }
-    }
-
-    /**
-     * Returns the public (mask) address, or null.
-     * @return the public (mask) address, or null.
-     */
-    public TransportAddress getMask()
-    {
-        if (mask == null)
-        {
-            obtainAddresses();
-        }
-        return mask;
-    }
-
-    /**
-     * Returns the local (face) address, or null.
-     * @return the local (face) address, or null.
-     */
-    public TransportAddress getFace()
-    {
-        if (face == null)
-        {
-            obtainAddresses();
-        }
-        return face;
     }
 }

--- a/src/main/java/org/ice4j/ice/harvest/TcpHarvester.java
+++ b/src/main/java/org/ice4j/ice/harvest/TcpHarvester.java
@@ -107,6 +107,7 @@ public class TcpHarvester
     {
         super(port);
         this.ssltcp = false;
+        addMappedAddresses();
     }
 
     /**
@@ -125,6 +126,7 @@ public class TcpHarvester
     {
         super(port, Collections.list(NetworkInterface.getNetworkInterfaces()));
         this.ssltcp = ssltcp;
+        addMappedAddresses();
     }
 
     /**
@@ -147,6 +149,7 @@ public class TcpHarvester
     {
         super(port, interfaces);
         this.ssltcp = ssltcp;
+        addMappedAddresses();
     }
 
     /**
@@ -163,6 +166,7 @@ public class TcpHarvester
     {
         super(transportAddresses);
         this.ssltcp = false;
+        addMappedAddresses();
     }
 
     /**
@@ -182,6 +186,21 @@ public class TcpHarvester
     {
         super(transportAddresses);
         this.ssltcp = ssltcp;
+        addMappedAddresses();
+    }
+
+    /**
+     * Adds the mapped addresses known from {@link MappingCandidateHarvesters}.
+     */
+    private void addMappedAddresses()
+    {
+        for (MappingCandidateHarvester harvester
+                    : MappingCandidateHarvesters.getHarvesters())
+        {
+            addMappedAddress(
+                    harvester.getMask().getAddress(),
+                    harvester.getFace().getAddress());
+        }
     }
 
     /**
@@ -196,6 +215,11 @@ public class TcpHarvester
     public void addMappedAddress(InetAddress publicAddress,
                                  InetAddress localAddress)
     {
+        if (logger.isLoggable(Level.FINE))
+        {
+            logger.fine("Adding a mapped address: " + localAddress
+                            + " => " + publicAddress);
+        }
         mappedAddresses.put(publicAddress, localAddress);
     }
 


### PR DESCRIPTION
Moves the mapping harvesters' configuration from jitsi-videobridge to ice4j. Automatically adds mapping harvesters to Agents. Re-implements the STUN mapping harvester in a way which allows discrimination between a failure of the STUN server and a match between the local and public addresses.