### PR TITLE
Networkutils rfc2732

### DIFF
--- a/src/main/java/org/ice4j/ice/NetworkUtils.java
+++ b/src/main/java/org/ice4j/ice/NetworkUtils.java
@@ -399,6 +399,15 @@ public class NetworkUtils
 
         colonIndex = -1;
         int i = 0, j = 0;
+
+        // Can be wrapped in []
+        if (addrBuff[i] == '[')
+        {
+            ++i;
+            if (scopeID == -1)
+                --srcb_length;
+        }
+
         // Starting : mean we need to have at least one more.
         if (addrBuff[i] == ':')
             if (addrBuff[++i] != ':')

--- a/src/test/java/org/ice4j/ice/NetworkUtilsTest.java
+++ b/src/test/java/org/ice4j/ice/NetworkUtilsTest.java
@@ -1,0 +1,47 @@
+/*
+ * ice4j, the OpenSource Java Solution for NAT and Firewall Traversal.
+ *
+ * Copyright @ 2015 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ice4j.ice;
+
+import static org.junit.Assert.*;
+
+import org.junit.*;
+
+public class NetworkUtilsTest
+{
+    @Test
+    public void testIpv6StringToBytes()
+    {
+        byte[] addr = NetworkUtils.strToIPv6("::12");
+        assertNotNull(addr);
+        assertEquals(18, addr[15]);
+
+        addr = NetworkUtils.strToIPv6("[::12]");
+        assertNotNull(addr);
+        assertEquals(18, addr[15]);
+
+        addr = NetworkUtils.strToIPv6("::12%1");
+        assertNotNull(addr);
+        assertEquals(18, addr[15]);
+
+        addr = NetworkUtils.strToIPv6("[::12%1]");
+        assertNotNull(addr);
+        assertEquals(18, addr[15]);
+
+        assertNull(NetworkUtils.strToIPv6("[::12]%1"));
+    }
+}


### PR DESCRIPTION
Previously bracketed addresses provided to strToIPv6 would return null.