### PR TITLE
	change MultiplexingXXXSocketSuppport::receive to 'trade' buffers in order to avoid a packet buffer allocation/copy.

### DIFF
--- a/src/main/java/org/ice4j/socket/MultiplexingXXXSocketSupport.java
+++ b/src/main/java/org/ice4j/socket/MultiplexingXXXSocketSupport.java
@@ -632,13 +632,8 @@ abstract class MultiplexingXXXSocketSupport
                     continue;
                 }
 
-                // The caller will receive from the network.
-                // Note(brian): since the packet passed in already has a valid buffer,
-                //  we'll use that to do the actual receive.  When we loop back around again
-                //  to actually get a packet to return, we'll 'steal' the info and data from
-                //  the packet object we remove, and put that into the passed packet 'p'
-                //DatagramPacket c = clone(p, /* arraycopy */ false);
-
+                // We'll use the passed-in packet to do the receive and then put that 
+                // packet on the back of the queue.
                 synchronized (receiveSyncRoot)
                 {
                     if (setReceiveBufferSize)
@@ -672,7 +667,9 @@ abstract class MultiplexingXXXSocketSupport
         }
         while (true);
 
-        //copy(r, p);
+        // The packet that was passed in is now in use at the end of the queue,
+        // so we'll 'steal' the buffers/information from the packet we just read
+        // off of the front of the queue and give it to the passed-in packet
         move(r, p);
     }
 


### PR DESCRIPTION
Currently, even though the passed-in packet has a buffer already allocated, we allocate a new buffer to receive a packet and put it on the buffer.  When we're ready to fill the given packet with the received data, we copy into the given buffer.
Instead, we can 'trade' the buffers: the passed-in packet's buffer will be used to perform the receive and then added to the queue.  The packet at the front of the queue (which will be discarded anyway) will have its buffer 'stolen' by the passed-in
packet instance. By doing this we can avoid a large buffer allocation and a copy for every packet.