### PR TITLE
specify where to apply configurations

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,6 +1,7 @@
 # General
-This file describes some of the java properties which ```ice4j``` uses
-to configure itself.
+This file describes some of the java properties which ```ice4j``` uses to configure
+itself in /etc/jitsi/videobridge/sip-communicator.properties if installed from package,
+or in $HOME/.sip-communicator/sip-communicator.properties if running from source.
 
 ## Interfaces and IP addresses
 


### PR DESCRIPTION
According to https://github.com/jitsi/jitsi-meet/issues/1390#issuecomment-300355464 configurations of `ice4j` are applied in the same place as `jitsi-videobridge`.

At the moment this is not clear in ice4j/doc/configuration.md

As a proposal to avoid (this/my) confusion I used a piece of text from [jitsi-videobridge/doc/http.md](https://github.com/jitsi/jitsi-videobridge/blob/9f13b7365512b946eff1703838b496aeacebda25/doc/http.md)  