### PR TITLE
Fixes leak of file descriptors

### DIFF
--- a/src/main/java/org/ice4j/socket/DelegatingDatagramSocket.java
+++ b/src/main/java/org/ice4j/socket/DelegatingDatagramSocket.java
@@ -116,6 +116,11 @@ public class DelegatingDatagramSocket
     private long nbSentPackets = 0;
 
     /**
+     * Whether this socket has been closed.
+     */
+    private boolean closed = false;
+
+    /**
      * Initializes a new <tt>DelegatingDatagramSocket</tt> instance and binds it
      * to any available port on the local host machine.  The socket will be
      * bound to the wildcard address, an IP address chosen by the kernel.
@@ -282,10 +287,14 @@ public class DelegatingDatagramSocket
     @Override
     public void close()
     {
+        // We want both #delegate and super to actually get closed (and release
+        // the FDs which they hold). But super will not close unless isClosed()
+        // returns false. So we update the #closed flag last.
         if (delegate != null)
             delegate.close();
 
         super.close();
+        closed = true;
     }
 
     /**
@@ -610,7 +619,7 @@ public class DelegatingDatagramSocket
     @Override
     public boolean isClosed()
     {
-        return (delegate == null) ? super.isClosed() : delegate.isClosed();
+        return closed;
     }
 
     /**

--- a/src/main/java/org/ice4j/socket/DelegatingDatagramSocket.java
+++ b/src/main/java/org/ice4j/socket/DelegatingDatagramSocket.java
@@ -282,10 +282,10 @@ public class DelegatingDatagramSocket
     @Override
     public void close()
     {
-        if (delegate == null)
-            super.close();
-        else
+        if (delegate != null)
             delegate.close();
+
+        super.close();
     }
 
     /**

--- a/src/main/java/org/ice4j/socket/MultiplexedDatagramSocket.java
+++ b/src/main/java/org/ice4j/socket/MultiplexedDatagramSocket.java
@@ -118,6 +118,8 @@ public class MultiplexedDatagramSocket
     public void close()
     {
         multiplexing.close(this);
+
+        super.close();
     }
 
     /**

--- a/src/main/java/org/ice4j/socket/RelayedCandidateDatagramSocket.java
+++ b/src/main/java/org/ice4j/socket/RelayedCandidateDatagramSocket.java
@@ -350,6 +350,8 @@ public class RelayedCandidateDatagramSocket
                 turnCandidateHarvest.hostCandidate.getTransportAddress(),
                 this);
         turnCandidateHarvest.close(this);
+
+        super.close();
     }
 
     /**


### PR DESCRIPTION
The problem was reproduced with java7 and defining multiple ipv6 fake(not-operational) addresses to one of the interfaces and running for a while.
Fixes jitsi/jitsi-meet#1390 and fixes jitsi/jicofo#167.