### PR TITLE
Preparations for releasing to Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <artifactId>ice4j</artifactId>
-  <version>2.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>ice4j</name>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,38 @@
           </includes>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>com.github.siom79.japicmp</groupId>
+        <artifactId>japicmp-maven-plugin</artifactId>
+        <version>0.10.0</version>
+        <configuration>
+          <newVersion>
+            <file>
+              <path>${project.build.directory}/${project.build.finalName}.jar</path>
+            </file>
+          </newVersion>
+          <oldVersion>
+            <dependency>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>${project.artifactId}</artifactId>
+              <version>1.0.0</version>
+            </dependency>
+          </oldVersion>
+          <parameter>
+            <onlyModified>true</onlyModified>
+            <breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
+            <reportOnlyFilename>true</reportOnlyFilename>
+          </parameter>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>cmp</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
 
     <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
 
   <profiles>
     <profile>
+      <id>skip-pre-jdk8</id>
       <activation>
         <jdk>(,1.8)</jdk>
       </activation>


### PR DESCRIPTION
This change to the POM will fail the build when the project version doesn't adhere to semantic versioning, i.e. when the source or binary compatibility is broken a new major version must be set.

This is a preparation for #95.