### PR TITLE
Add MESSAGE_INTEGRITY to indications

### DIFF
--- a/src/main/java/org/ice4j/attribute/MessageIntegrityAttribute.java
+++ b/src/main/java/org/ice4j/attribute/MessageIntegrityAttribute.java
@@ -283,7 +283,7 @@ public class MessageIntegrityAttribute
         char msgType =
             (char) (((content[0] & 0xFF) << 8) | (content[1] & 0xFF));
 
-        if(Message.isRequestType(msgType))
+        if(Message.isRequestType(msgType) || Message.isIndicationType(msgType))
         {
             /* attribute part of a request, use the remote key */
             key = stunStack.getCredentialsManager().getRemoteKey(username,


### PR DESCRIPTION
RFC 5389 Section 10.1.1
>  For a request or indication message, the agent MUST include the USERNAME and MESSAGE-INTEGRITY attributes in the message.