### PR TITLE
Fixes a race condition leading to a thread stuck in receive()

### DIFF
--- a/src/main/java/org/ice4j/ice/harvest/AbstractUdpListener.java
+++ b/src/main/java/org/ice4j/ice/harvest/AbstractUdpListener.java
@@ -535,10 +535,10 @@ public abstract class AbstractUdpListener
         @Override
         public void close()
         {
-            closed = true;
-
             synchronized (queue)
             {
+                closed = true;
+
                 // Wake up any threads still in receive()
                 queue.notifyAll();
             }
@@ -565,11 +565,13 @@ public abstract class AbstractUdpListener
 
             while (buf == null)
             {
-                if (closed)
-                    throw new SocketException("Socket closed");
-
                 synchronized (queue)
                 {
+                    if (closed)
+                    {
+                        throw new SocketException("Socket closed");
+                    }
+
                     if (queue.isEmpty())
                     {
                         try

--- a/src/main/java/org/ice4j/ice/harvest/AbstractUdpListener.java
+++ b/src/main/java/org/ice4j/ice/harvest/AbstractUdpListener.java
@@ -546,7 +546,9 @@ public abstract class AbstractUdpListener
             // We could be called by the super-class constructor, in which
             // case this.removeAddress is not initialized yet.
             if (remoteAddress != null)
+            {
                 AbstractUdpListener.this.sockets.remove(remoteAddress);
+            }
 
             super.close();
         }
@@ -594,7 +596,9 @@ public abstract class AbstractUdpListener
 
             // XXX Should we use p.setData() here with a buffer of our own?
             if (pData == null || pData.length < buf.len)
+            {
                 throw new IOException("packet buffer not available");
+            }
 
             System.arraycopy(buf.buffer, 0, pData, 0, buf.len);
             p.setLength(buf.len);

--- a/src/main/java/org/ice4j/socket/SafeCloseDatagramSocket.java
+++ b/src/main/java/org/ice4j/socket/SafeCloseDatagramSocket.java
@@ -143,9 +143,6 @@ public class SafeCloseDatagramSocket
     {
         super.close();
 
-        if(inReceiveSyncRoot == null)
-            return;
-
         synchronized (inReceiveSyncRoot)
         {
             boolean interrupted = false;


### PR DESCRIPTION
This was observed in jitsi-videobridge, where it eventually led to the expire thread being blocked.