### PR TITLE
AbstractUdpListener should be able to release its resources

### DIFF
--- a/src/main/java/org/ice4j/ice/harvest/AbstractUdpListener.java
+++ b/src/main/java/org/ice4j/ice/harvest/AbstractUdpListener.java
@@ -197,6 +197,11 @@ public abstract class AbstractUdpListener
     private final Thread thread;
 
     /**
+     * Triggers the termination of the threads of this instance.
+     */
+    private boolean close = false;
+
+    /**
      * Initializes a new <tt>SinglePortUdpHarvester</tt> instance which is to
      * bind on the specified local address.
      * @param localAddress the address to bind to.
@@ -255,6 +260,15 @@ public abstract class AbstractUdpListener
     }
 
     /**
+     * Triggers the termination of the threads of this instance.
+     */
+    public void close()
+    {
+        close = true;
+        socket.close(); // causes socket#receive to stop blocking.
+    }
+
+    /**
      * Perpetually reads datagrams from {@link #socket} and handles them
      * accordingly.
      *
@@ -271,7 +285,10 @@ public abstract class AbstractUdpListener
 
         do
         {
-            // TODO: implement stopping the thread with a switch?
+            if (close)
+            {
+                break;
+            }
 
             buf = getFreeBuffer();
 
@@ -286,7 +303,10 @@ public abstract class AbstractUdpListener
             }
             catch (IOException ioe)
             {
-                logger.severe("Failed to receive from socket: " + ioe);
+                if (!close)
+                {
+                    logger.severe("Failed to receive from socket: " + ioe);
+                }
                 break;
             }
             buf.len = pkt.getLength();
@@ -316,7 +336,12 @@ public abstract class AbstractUdpListener
         }
         while (true);
 
-        // TODO we are all done, clean up.
+        //now clean up and exit
+        for (MySocket candidateSocket : sockets.values())
+        {
+            candidateSocket.close();
+        }
+        socket.close();
     }
 
     /**

--- a/src/main/java/org/ice4j/ice/harvest/AbstractUdpListener.java
+++ b/src/main/java/org/ice4j/ice/harvest/AbstractUdpListener.java
@@ -336,8 +336,8 @@ public abstract class AbstractUdpListener
         }
         while (true);
 
-        //now clean up and exit
-        for (MySocket candidateSocket : sockets.values())
+        // now clean up and exit
+        for (MySocket candidateSocket : new ArrayList<>(sockets.values()))
         {
             candidateSocket.close();
         }

--- a/src/test/java/org/ice4j/ice/harvest/SinglePortUdpHarvesterTest.java
+++ b/src/test/java/org/ice4j/ice/harvest/SinglePortUdpHarvesterTest.java
@@ -1,0 +1,96 @@
+package org.ice4j.ice.harvest;
+
+import org.ice4j.Transport;
+import org.ice4j.TransportAddress;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.BindException;
+
+/**
+ * Various tests that verify the functionality provided by {@link SinglePortUdpHarvester}.
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+public class SinglePortUdpHarvesterTest
+{
+    /**
+     * Verifies that, without closing, the address used by a harvester cannot be re-used.
+     *
+     * @see <a href="https://github.com/jitsi/ice4j/issues/139">https://github.com/jitsi/ice4j/issues/139</a>
+     */
+    @Test( expected = java.net.BindException.class )
+    public void testRebindWithoutClose() throws Exception
+    {
+        // Setup test fixture.
+        final TransportAddress address = new TransportAddress( "127.0.0.1", 10000, Transport.UDP );
+        SinglePortUdpHarvester firstHarvester;
+        try
+        {
+            firstHarvester = new SinglePortUdpHarvester( address );
+        }
+        catch ( java.net.BindException ex )
+        {
+            // This is not expected at this stage (the port is likely already in use by another process, voiding this
+            // test). Rethrow as a different exception than the BindException, that is expected to be thrown later in
+            // this test.
+            throw new Exception( "Test fixture is invalid.", ex );
+        }
+
+        // Execute system under test.
+        SinglePortUdpHarvester secondHarvester = null;
+        try
+        {
+            secondHarvester = new SinglePortUdpHarvester( address );
+        }
+        // Verification of the results is implicit - this Test expectes BindException to be thrown at this point.
+
+        // Tear down
+        finally
+        {
+            firstHarvester.close();
+            if ( secondHarvester != null )
+            {
+                secondHarvester.close();
+            }
+        }
+    }
+
+    /**
+     * Verifies that, after closing, the address used by a harvester can be re-used.
+     *
+     * @see <a href="https://github.com/jitsi/ice4j/issues/139">https://github.com/jitsi/ice4j/issues/139</a>
+     */
+    @Test
+    public void testRebindWithClose() throws Exception
+    {
+        // Setup test fixture.
+        final TransportAddress address = new TransportAddress( "127.0.0.1", 10001, Transport.UDP );
+        final SinglePortUdpHarvester firstHarvester = new SinglePortUdpHarvester( address );
+        firstHarvester.close();
+        Thread.sleep(500 ); // give thread time to close/clean up.
+
+        // Execute system under test.
+        SinglePortUdpHarvester secondHarvester = null;
+
+        try
+        {
+            secondHarvester = new SinglePortUdpHarvester( address );
+        }
+
+        // Verify results.
+        catch ( BindException ex )
+        {
+            Assert.fail( "A bind exception should not have been thrown, as the original harvester was propertly closed.");
+        }
+
+        // Tear down.
+        finally
+        {
+            if ( secondHarvester != null )
+            {
+                secondHarvester.close();
+            }
+        }
+    }
+}

--- a/src/test/java/org/ice4j/ice/harvest/SinglePortUdpHarvesterTest.java
+++ b/src/test/java/org/ice4j/ice/harvest/SinglePortUdpHarvesterTest.java
@@ -1,11 +1,26 @@
+/*
+ * ice4j, the OpenSource Java Solution for NAT and Firewall Traversal.
+ *
+ * Copyright @ 2018 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.ice4j.ice.harvest;
 
-import org.ice4j.Transport;
-import org.ice4j.TransportAddress;
-import org.junit.Assert;
-import org.junit.Test;
+import org.ice4j.*;
+import org.junit.*;
 
-import java.net.BindException;
+import java.net.*;
 
 /**
  * Various tests that verify the functionality provided by {@link SinglePortUdpHarvester}.
@@ -68,7 +83,7 @@ public class SinglePortUdpHarvesterTest
         final TransportAddress address = new TransportAddress( "127.0.0.1", 10001, Transport.UDP );
         final SinglePortUdpHarvester firstHarvester = new SinglePortUdpHarvester( address );
         firstHarvester.close();
-        Thread.sleep(500 ); // give thread time to close/clean up.
+        Thread.sleep( 500 ); // give thread time to close/clean up.
 
         // Execute system under test.
         SinglePortUdpHarvester secondHarvester = null;


### PR DESCRIPTION
A new 'close' method has been added to AbstractUdpListener that is modeled after the 'close' implementation of AbstractTcpListener.

This change can be used to prevent the issue described in https://github.com/jitsi/ice4j/issues/139