### PR TITLE
Reduce number of threads created by ice4j. Eliminate StunKeepAliveThread.

### DIFF
--- a/src/main/java/org/ice4j/ice/Agent.java
+++ b/src/main/java/org/ice4j/ice/Agent.java
@@ -132,6 +132,10 @@ public class Agent
             {
                 Thread thread = defaultThreadFactory.newThread(r);
                 thread.setName("ice4j.Agent-" + thread.getName());
+                if (!thread.isDaemon())
+                {
+                    thread.setDaemon(true);
+                }
                 return thread;
             }
         };

--- a/src/main/java/org/ice4j/ice/Agent.java
+++ b/src/main/java/org/ice4j/ice/Agent.java
@@ -153,7 +153,7 @@ public class Agent
     };
 
     /**
-     * Schedule STUN checks for selected pair.
+     * A runnable instance to schedule STUN checks for selected pair.
      */
     private final StunKeepAliveRunnable
         stunKeepAliveRunnable = new StunKeepAliveRunnable();
@@ -2696,7 +2696,7 @@ public class Agent
     }
 
     /**
-     * Schedulable task to perform Stun Keep Alive
+     * Schedulable task to perform Stun keep-alive checks
      */
     private final class StunKeepAliveRunnable implements Runnable
     {

--- a/src/main/java/org/ice4j/ice/Agent.java
+++ b/src/main/java/org/ice4j/ice/Agent.java
@@ -215,11 +215,11 @@ public class Agent
         }
 
         private void maybeCancelFurtherKeepAlives() {
-            if (!runInStunKeepAliveThreadCondition())
+            if (!runStunKeepAliveCondition())
             {
                 synchronized (stunKeepAliveFutureSyncRoot)
                 {
-                    if (!runInStunKeepAliveThreadCondition())
+                    if (!runStunKeepAliveCondition())
                     {
                         if (stunKeepAliveFuture != null)
                         {
@@ -2323,11 +2323,8 @@ public class Agent
             = StackProperties.getBoolean(
                 StackProperties.NO_KEEP_ALIVES,
                 false);
-        if (noKeepAlives) {
-            return;
-        }
-
-        if (!runInStunKeepAliveThreadCondition()) {
+        if (noKeepAlives || !runStunKeepAliveCondition())
+        {
             return;
         }
 
@@ -2337,6 +2334,8 @@ public class Agent
             {
                 if (stunKeepAliveFuture == null)
                 {
+                    logger.info("Starting periodic Stun Keep Alive.");
+
                     long consentFreshnessInterval = Long.getLong(
                         StackProperties.CONSENT_FRESHNESS_INTERVAL,
                         DEFAULT_CONSENT_FRESHNESS_INTERVAL);
@@ -2555,7 +2554,7 @@ public class Agent
      * @return <tt>true</tt> if <tt>{@link #stunKeepAliveRunnable}</tt> is to run;
      * otherwise, <tt>false</tt>
      */
-    private boolean runInStunKeepAliveThreadCondition()
+    private boolean runStunKeepAliveCondition()
     {
         IceProcessingState state = this.state;
 

--- a/src/main/java/org/ice4j/ice/Agent.java
+++ b/src/main/java/org/ice4j/ice/Agent.java
@@ -2327,6 +2327,10 @@ public class Agent
             return;
         }
 
+        if (!runInStunKeepAliveThreadCondition()) {
+            return;
+        }
+
         if (stunKeepAliveFuture == null)
         {
             synchronized (stunKeepAliveFutureSyncRoot)

--- a/src/main/java/org/ice4j/ice/Agent.java
+++ b/src/main/java/org/ice4j/ice/Agent.java
@@ -214,7 +214,8 @@ public class Agent
             maybeCancelFurtherKeepAlives();
         }
 
-        private void maybeCancelFurtherKeepAlives() {
+        private void maybeCancelFurtherKeepAlives()
+        {
             if (!runStunKeepAliveCondition())
             {
                 synchronized (stunKeepAliveFutureSyncRoot)
@@ -223,8 +224,7 @@ public class Agent
                     {
                         if (stunKeepAliveFuture != null)
                         {
-                            stunKeepAliveFuture.cancel(
-                                false);
+                            stunKeepAliveFuture.cancel(false);
                             stunKeepAliveFuture = null;
                             logger.info("Stop periodic Stun Keep Alive.");
                         }

--- a/src/main/java/org/ice4j/ice/Agent.java
+++ b/src/main/java/org/ice4j/ice/Agent.java
@@ -29,6 +29,7 @@ import java.util.logging.*;
 import org.ice4j.*;
 import org.ice4j.ice.harvest.*;
 import org.ice4j.stack.*;
+import org.ice4j.util.*;
 import org.ice4j.util.Logger; // Disambiguation.
 
 /**
@@ -122,26 +123,11 @@ public class Agent
 
     static
     {
-        final ThreadFactory agentThreadFactory = new ThreadFactory()
-        {
-            private final ThreadFactory defaultThreadFactory
-                = Executors.defaultThreadFactory();
-
-            @Override
-            public Thread newThread(Runnable r)
-            {
-                Thread thread = defaultThreadFactory.newThread(r);
-                thread.setName("ice4j.Agent-" + thread.getName());
-                if (!thread.isDaemon())
-                {
-                    thread.setDaemon(true);
-                }
-                return thread;
-            }
-        };
+        CustomizableThreadFactory threadFactory
+            = new CustomizableThreadFactory("ice4j.Agent-", true);
 
         final ScheduledThreadPoolExecutor terminationExecutor
-            = new ScheduledThreadPoolExecutor(0, agentThreadFactory);
+            = new ScheduledThreadPoolExecutor(0, threadFactory);
         terminationExecutor.setKeepAliveTime(10, TimeUnit.SECONDS);
         terminationExecutor.setRemoveOnCancelPolicy(true);
         agentTasksScheduler

--- a/src/main/java/org/ice4j/ice/Agent.java
+++ b/src/main/java/org/ice4j/ice/Agent.java
@@ -216,11 +216,11 @@ public class Agent
 
         private void maybeCancelFurtherKeepAlives()
         {
-            if (!runStunKeepAliveCondition())
+            if (!shouldRunStunKeepAlive())
             {
                 synchronized (stunKeepAliveFutureSyncRoot)
                 {
-                    if (!runStunKeepAliveCondition())
+                    if (!shouldRunStunKeepAlive())
                     {
                         if (stunKeepAliveFuture != null)
                         {
@@ -2323,7 +2323,7 @@ public class Agent
             = StackProperties.getBoolean(
                 StackProperties.NO_KEEP_ALIVES,
                 false);
-        if (noKeepAlives || !runStunKeepAliveCondition())
+        if (noKeepAlives || !shouldRunStunKeepAlive())
         {
             return;
         }
@@ -2549,12 +2549,12 @@ public class Agent
 
 
     /**
-     * Determines whether {@link #stunKeepAliveRunnable} is to run.
+     * Determines whether {@link #stunKeepAliveRunnable} should run.
      *
-     * @return <tt>true</tt> if <tt>{@link #stunKeepAliveRunnable}</tt> is to run;
-     * otherwise, <tt>false</tt>
+     * @return <tt>true</tt> if <tt>{@link #stunKeepAliveRunnable}</tt> should
+     * run otherwise, <tt>false</tt>
      */
-    private boolean runStunKeepAliveCondition()
+    private boolean shouldRunStunKeepAlive()
     {
         IceProcessingState state = this.state;
 

--- a/src/main/java/org/ice4j/util/CustomizableThreadFactory.java
+++ b/src/main/java/org/ice4j/util/CustomizableThreadFactory.java
@@ -20,6 +20,10 @@ package org.ice4j.util;
 
 import java.util.concurrent.*;
 
+/**
+ * A thread factory which supports customizing name prefix of created threads
+ * and if produced threads are daemons or not.
+ */
 public final class CustomizableThreadFactory implements ThreadFactory
 {
     private final ThreadFactory defaultThreadFactory

--- a/src/main/java/org/ice4j/util/CustomizableThreadFactory.java
+++ b/src/main/java/org/ice4j/util/CustomizableThreadFactory.java
@@ -25,9 +25,9 @@ public final class CustomizableThreadFactory implements ThreadFactory
     private final ThreadFactory defaultThreadFactory
         = Executors.defaultThreadFactory();
 
-    private String threadNamePrefix;
+    private final String threadNamePrefix;
 
-    private boolean isDaemon;
+    private final boolean isDaemon;
 
     public CustomizableThreadFactory(String threadNamePrefix, boolean isDaemon)
     {

--- a/src/main/java/org/ice4j/util/CustomizableThreadFactory.java
+++ b/src/main/java/org/ice4j/util/CustomizableThreadFactory.java
@@ -1,0 +1,52 @@
+/*
+ * ice4j, the OpenSource Java Solution for NAT and Firewall Traversal.
+ *
+ * Copyright @ 2018 Jitsi.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ice4j.util;
+
+import java.util.concurrent.*;
+
+public final class CustomizableThreadFactory implements ThreadFactory
+{
+    private final ThreadFactory defaultThreadFactory
+        = Executors.defaultThreadFactory();
+
+    private String threadNamePrefix;
+
+    private boolean isDaemon;
+
+    public CustomizableThreadFactory(String threadNamePrefix, boolean isDaemon)
+    {
+        this.threadNamePrefix = threadNamePrefix;
+        this.isDaemon = isDaemon;
+    }
+
+    @Override
+    public Thread newThread(Runnable r)
+    {
+        Thread thread = this.defaultThreadFactory.newThread(r);
+        if (this.threadNamePrefix != null && !threadNamePrefix.isEmpty())
+        {
+            thread.setName(this.threadNamePrefix + thread.getName());
+        }
+        if (thread.isDaemon() != this.isDaemon)
+        {
+            thread.setDaemon(this.isDaemon);
+        }
+        return thread;
+    }
+}


### PR DESCRIPTION
Replaced manual scheduling of repeated Stun Keep Alive with `ScheduledExecutorService`.
Observed enhancement in my environment: 30 conferences with 3 audio only peers each.
**Before**: `90` instances of `StunKeepAliveThread`
**After**: single `Thread` instance in thread pool which handles both termination & stun keep alive.
