### PR TITLE
Reduce number of threads created by ice4j. Eliminate ICE PaceMaker thread & Timer.

### DIFF
--- a/src/main/java/org/ice4j/ice/Agent.java
+++ b/src/main/java/org/ice4j/ice/Agent.java
@@ -383,7 +383,7 @@ public class Agent
         SecureRandom random = new SecureRandom();
 
         connCheckServer = new ConnectivityCheckServer(this);
-        connCheckClient = new ConnectivityCheckClient(this);
+        connCheckClient = new ConnectivityCheckClient(this, agentTasksScheduler);
 
         //add the FINGERPRINT attribute to all messages.
         System.setProperty(StackProperties.ALWAYS_SIGN, "true");

--- a/src/main/java/org/ice4j/ice/ConnectivityCheckClient.java
+++ b/src/main/java/org/ice4j/ice/ConnectivityCheckClient.java
@@ -895,7 +895,9 @@ class ConnectivityCheckClient
 
                 //if there are no triggered checks, go for an ordinary one.
                 if (pairToCheck == null)
+                {
                     pairToCheck = checkList.getNextOrdinaryPairToCheck();
+                }
 
                 if (pairToCheck != null)
                 {
@@ -919,7 +921,9 @@ class ConnectivityCheckClient
                             pairToCheck.setStateFailed();
                         }
                         else
+                        {
                             pairToCheck.setStateInProgress(transactionID);
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
Replaced manual recurrent `Thread`-based scheduling of `CheckList` checks with `ScheduledExecutorService `.
Replaced `Timer`, which under the hood creates `Thread` with `ScheduledExecutorService `.

Observed enhancement in my environment: 30 conferences with 3 audio only peers each.
**Before**: **181** instances of `ICE PaceMaker` thread.
**After**: **1** `Thread` instance inside thread pool which handles termination & stun keep alives & ICE PaceMaker.