### PR TITLE
Eliminate "Stun4J Message Processor" by replacing it with thread pool.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,14 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
       </plugin>
@@ -126,26 +134,6 @@
   </build>
 
   <profiles>
-    <profile>
-      <id>skip-pre-jdk8</id>
-      <activation>
-        <jdk>(,1.8)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <excludes>
-                <exclude>**/jdk8/**</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
     <profile>
       <id>run-sample</id>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -44,14 +44,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
       </plugin>
@@ -134,6 +126,26 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>skip-pre-jdk8</id>
+      <activation>
+        <jdk>(,1.8)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <excludes>
+                <exclude>**/jdk8/**</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>run-sample</id>
       <build>

--- a/src/main/java/org/ice4j/stack/Connector.java
+++ b/src/main/java/org/ice4j/stack/Connector.java
@@ -20,7 +20,7 @@ package org.ice4j.stack;
 import java.io.*;
 import java.net.*;
 import java.nio.channels.*;
-import java.util.concurrent.*;
+import java.util.function.*;
 import java.util.logging.*;
 
 import org.ice4j.*;
@@ -44,9 +44,9 @@ class Connector
         = Logger.getLogger(Connector.class.getName());
 
     /**
-     * The message queue is where incoming messages are added.
+     * The consumer of incoming <tt>RawMessage</tt>s
      */
-    private final BlockingQueue<RawMessage> messageQueue;
+    private final Consumer<RawMessage> messageConsumer;
 
     /**
      * The socket object that used by this access point to access the network.
@@ -87,16 +87,16 @@ class Connector
      * communication.
      * @param remoteAddress the remote address of the socket of this
      * {@link Connector} if it is a TCP socket, or null if it is UDP.
-     * @param messageQueue the Queue where incoming messages should be queued
+     * @param messageConsumer the incoming messages consumer
      * @param errorHandler the instance to notify when errors occur.
      */
     protected Connector(IceSocketWrapper socket,
                         TransportAddress remoteAddress,
-                        BlockingQueue<RawMessage> messageQueue,
+                        Consumer<RawMessage> messageConsumer,
                         ErrorHandler   errorHandler)
     {
         this.sock = socket;
-        this.messageQueue = messageQueue;
+        this.messageConsumer = messageConsumer;
         this.errorHandler = errorHandler;
         this.remoteAddress = remoteAddress;
 
@@ -230,7 +230,7 @@ class Connector
                                     listenAddress.getTransport()),
                             listenAddress);
 
-                messageQueue.add(rawMessage);
+                messageConsumer.accept(rawMessage);
             }
             catch (SocketException ex)
             {

--- a/src/main/java/org/ice4j/stack/Connector.java
+++ b/src/main/java/org/ice4j/stack/Connector.java
@@ -29,8 +29,9 @@ import org.ice4j.socket.*;
 /**
  * The Network Access Point is the most outward part of the stack. It is
  * constructed around a datagram socket and takes care of forwarding incoming
- * messages to the MessageProcessingTask as well as sending datagrams to
- * the STUN server specified by the original NetAccessPointDescriptor.
+ * messages to the provided {@link #messageConsumer} as well as sending
+ * datagrams to the STUN server specified by the
+ * original NetAccessPointDescriptor.
  *
  * @author Emil Ivov
  */

--- a/src/main/java/org/ice4j/stack/Connector.java
+++ b/src/main/java/org/ice4j/stack/Connector.java
@@ -29,8 +29,8 @@ import org.ice4j.socket.*;
 /**
  * The Network Access Point is the most outward part of the stack. It is
  * constructed around a datagram socket and takes care of forwarding incoming
- * messages to the MessageProcessor as well as sending datagrams to the STUN
- * server specified by the original NetAccessPointDescriptor.
+ * messages to the MessageProcessingTask as well as sending datagrams to
+ * the STUN server specified by the original NetAccessPointDescriptor.
  *
  * @author Emil Ivov
  */

--- a/src/main/java/org/ice4j/stack/MessageProcessingTask.java
+++ b/src/main/java/org/ice4j/stack/MessageProcessingTask.java
@@ -87,8 +87,7 @@ class MessageProcessingTask
      * @throws IllegalArgumentException if any of the mentioned properties of
      * <tt>netAccessManager</tt> are <tt>null</tt>
      */
-    MessageProcessingTask(
-        NetAccessManager netAccessManager)
+    MessageProcessingTask(NetAccessManager netAccessManager)
         throws IllegalArgumentException
     {
         if (netAccessManager == null)

--- a/src/main/java/org/ice4j/stack/MessageProcessingTask.java
+++ b/src/main/java/org/ice4j/stack/MessageProcessingTask.java
@@ -123,8 +123,8 @@ class MessageProcessingTask
         {
             throw new IllegalArgumentException("The message may not be null");
         }
-        this.rawMessage = message;
-        this.rawMessageProcessedHandler = onProcessed;
+        rawMessage = message;
+        rawMessageProcessedHandler = onProcessed;
     }
 
     /**
@@ -132,9 +132,9 @@ class MessageProcessingTask
      */
     void resetState()
     {
-        this.cancelled.set(false);
-        this.rawMessage = null;
-        this.rawMessageProcessedHandler = null;
+        cancelled.set(false);
+        rawMessage = null;
+        rawMessageProcessedHandler = null;
     }
 
     /**
@@ -142,7 +142,7 @@ class MessageProcessingTask
      */
     public void cancel()
     {
-        this.cancelled.set(true);
+        cancelled.set(true);
     }
 
     @Override
@@ -161,7 +161,7 @@ class MessageProcessingTask
             rawMessage = null;
             rawMessageProcessedHandler = null;
 
-            if (this.cancelled.get())
+            if (cancelled.get())
             {
                 return;
             }

--- a/src/main/java/org/ice4j/stack/MessageProcessingTask.java
+++ b/src/main/java/org/ice4j/stack/MessageProcessingTask.java
@@ -99,7 +99,7 @@ class MessageProcessingTask
         MessageEventHandler messageEventHandler
             = netAccessManager.getMessageEventHandler();
 
-        if(messageEventHandler == null)
+        if (messageEventHandler == null)
         {
             throw new IllegalArgumentException(
                 "The message event handler may not be null");

--- a/src/main/java/org/ice4j/stack/MessageProcessingTask.java
+++ b/src/main/java/org/ice4j/stack/MessageProcessingTask.java
@@ -145,6 +145,9 @@ class MessageProcessingTask
         cancelled.set(true);
     }
 
+    /**
+     * Does the message parsing.
+     */
     @Override
     public void run()
     {

--- a/src/main/java/org/ice4j/stack/MessageProcessingTask.java
+++ b/src/main/java/org/ice4j/stack/MessageProcessingTask.java
@@ -17,7 +17,6 @@
  */
 package org.ice4j.stack;
 
-import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 import java.util.function.*;
 import java.util.logging.*;
@@ -27,11 +26,11 @@ import org.ice4j.message.*;
 
 /**
  * The class is used to parse and dispatch incoming messages by being
- * executed by concurrent {@link java.util.concurrent.ForkJoinPool}.
- * To reduce memory allocation this <tt>ForkJoinTask</tt> implementation
- * designed to be suitable for usage with pooling, the instance of this type is
- * mutable such that <tt>RawMessage</tt> can be updated and instance can be
- * reused and scheduled with new <tt>RawMessage</tt>
+ * executed by concurrent {@link java.util.concurrent.ExecutorService}.
+ * To reduce memory allocation this class is designed to be suitable for
+ * usage with pooling, the instance of this type is mutable such that
+ * <tt>RawMessage</tt> can be updated and instance can be reused and
+ * scheduled with new <tt>RawMessage</tt>
  *
  * @author Emil Ivov
  */

--- a/src/main/java/org/ice4j/stack/MessageProcessingTask.java
+++ b/src/main/java/org/ice4j/stack/MessageProcessingTask.java
@@ -33,6 +33,7 @@ import org.ice4j.message.*;
  * scheduled with new <tt>RawMessage</tt>
  *
  * @author Emil Ivov
+ * @author Yura Yaroshevich
  */
 class MessageProcessingTask
     implements Runnable

--- a/src/main/java/org/ice4j/stack/MessageProcessingTask.java
+++ b/src/main/java/org/ice4j/stack/MessageProcessingTask.java
@@ -110,7 +110,7 @@ class MessageProcessingTask
 
     /**
      * Assigns the <tt>RawMessage</tt> that will be processed
-     * by this <tt>MessageProcessingTask</tt> on separate thread.
+     * by this <tt>MessageProcessingTask</tt> on executor's thread.
      * @param message RawMessage to be processed
      * @param onProcessed callback which will be invoked when processing
      * of {@link #rawMessage} is completed

--- a/src/main/java/org/ice4j/stack/MessageProcessingTask.java
+++ b/src/main/java/org/ice4j/stack/MessageProcessingTask.java
@@ -35,17 +35,17 @@ import org.ice4j.message.*;
  *
  * @author Emil Ivov
  */
-class MessageProcessor
+class MessageProcessingTask
     extends RecursiveAction
 {
     /**
      * Our class logger.
      */
     private static final Logger logger
-        = Logger.getLogger(MessageProcessor.class.getName());
+        = Logger.getLogger(MessageProcessingTask.class.getName());
 
     /**
-     * Indicates that <tt>MessageProcessor</tt> is cancelled and should not
+     * Indicates that <tt>MessageProcessingTask</tt> is cancelled and should not
      * process <tt>RawMessage</tt> anymore.
      */
     private final AtomicBoolean cancelled = new AtomicBoolean(false);
@@ -72,10 +72,10 @@ class MessageProcessor
     private RawMessage rawMessage;
 
     /**
-     * Callback which is invoked when this <tt>MessageProcessor</tt>
+     * Callback which is invoked when this <tt>MessageProcessingTask</tt>
      * processed it's {@link #rawMessage}
      */
-    private Consumer<MessageProcessor> rawMessageProcessedHandler;
+    private Consumer<MessageProcessingTask> rawMessageProcessedHandler;
 
     /**
      * Creates a Message processor.
@@ -87,7 +87,7 @@ class MessageProcessor
      * @throws IllegalArgumentException if any of the mentioned properties of
      * <tt>netAccessManager</tt> are <tt>null</tt>
      */
-    MessageProcessor(
+    MessageProcessingTask(
         NetAccessManager netAccessManager)
         throws IllegalArgumentException
     {
@@ -112,12 +112,14 @@ class MessageProcessor
 
     /**
      * Assigns the <tt>RawMessage</tt> that will be processed
-     * by this <tt>MessageProcessor</tt> on separate thread.
+     * by this <tt>MessageProcessingTask</tt> on separate thread.
      * @param message RawMessage to be processed
      * @param onProcessed callback which will be invoked when processing
      * of {@link #rawMessage} is completed
      */
-    void setMessage(RawMessage message, Consumer<MessageProcessor> onProcessed)
+    void setMessage(
+        RawMessage message,
+        Consumer<MessageProcessingTask> onProcessed)
     {
         if (message == null)
         {
@@ -147,7 +149,8 @@ class MessageProcessor
     @Override
     protected void compute()
     {
-        final Consumer<MessageProcessor> onProcessed = rawMessageProcessedHandler;
+        final Consumer<MessageProcessingTask> onProcessed
+            = rawMessageProcessedHandler;
         final RawMessage message = rawMessage;
         //add an extra try/catch block that handles uncatched errors
         try

--- a/src/main/java/org/ice4j/stack/MessageProcessingTask.java
+++ b/src/main/java/org/ice4j/stack/MessageProcessingTask.java
@@ -36,7 +36,7 @@ import org.ice4j.message.*;
  * @author Emil Ivov
  */
 class MessageProcessingTask
-    extends RecursiveAction
+    implements Runnable
 {
     /**
      * Our class logger.
@@ -132,10 +132,11 @@ class MessageProcessingTask
     /**
      * Performs proper reset of internal state of pooled instance.
      */
-    public void resetState()
+    void resetState()
     {
-        this.reinitialize();
         this.cancelled.set(false);
+        this.rawMessage = null;
+        this.rawMessageProcessedHandler = null;
     }
 
     /**
@@ -147,7 +148,7 @@ class MessageProcessingTask
     }
 
     @Override
-    protected void compute()
+    public void run()
     {
         final Consumer<MessageProcessingTask> onProcessed
             = rawMessageProcessedHandler;

--- a/src/main/java/org/ice4j/stack/MessageProcessingTask.java
+++ b/src/main/java/org/ice4j/stack/MessageProcessingTask.java
@@ -191,7 +191,7 @@ class MessageProcessingTask
 
             messageEventHandler.handleMessageEvent(stunMessageEvent);
         }
-        catch(Throwable err)
+        catch (Throwable err)
         {
             errorHandler.handleFatalError(
                 Thread.currentThread(),

--- a/src/main/java/org/ice4j/stack/MessageProcessor.java
+++ b/src/main/java/org/ice4j/stack/MessageProcessor.java
@@ -197,10 +197,10 @@ class MessageProcessor
         }
         finally
         {
-            // On processed callback must be invoked in call cases, even when
+            // On processed callback must be invoked in all cases, even when
             // cancellation or early exist happen, otherwise
-            // NetAccessManager internal tracking of pooled and active objects
-            // will be confused.
+            // NetAccessManager internal tracking of pooled and active
+            // message processors will missbehave.
             if (onProcessed != null)
             {
                 onProcessed.accept(this);

--- a/src/main/java/org/ice4j/stack/MessageProcessor.java
+++ b/src/main/java/org/ice4j/stack/MessageProcessor.java
@@ -27,9 +27,9 @@ import org.ice4j.message.*;
 
 /**
  * The class is used to parse and dispatch incoming messages by being
- * executed by concurrent {@link java.util.concurrent.ExecutorService}.
- * To reduce memory allocation this <tt>Runnable</tt> implementation designed
- * to be suitable for usage with pooling, the instance of this type is
+ * executed by concurrent {@link java.util.concurrent.ForkJoinPool}.
+ * To reduce memory allocation this <tt>ForkJoinTask</tt> implementation
+ * designed to be suitable for usage with pooling, the instance of this type is
  * mutable such that <tt>RawMessage</tt> can be updated and instance can be
  * reused and scheduled with new <tt>RawMessage</tt>
  *

--- a/src/main/java/org/ice4j/stack/MessageProcessor.java
+++ b/src/main/java/org/ice4j/stack/MessageProcessor.java
@@ -17,6 +17,7 @@
  */
 package org.ice4j.stack;
 
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 import java.util.function.*;
 import java.util.logging.*;
@@ -35,7 +36,7 @@ import org.ice4j.message.*;
  * @author Emil Ivov
  */
 class MessageProcessor
-    implements Runnable
+    extends RecursiveAction
 {
     /**
      * Our class logger.
@@ -131,10 +132,8 @@ class MessageProcessor
         this.cancelled.set(true);
     }
 
-    /**
-     * Does the message parsing.
-     */
-    public void run()
+    @Override
+    protected void compute()
     {
         final Consumer<MessageProcessor> onProcessed = rawMessageProcessedHandler;
         final RawMessage message = rawMessage;
@@ -180,7 +179,9 @@ class MessageProcessor
         }
         catch(Throwable err)
         {
-            errorHandler.handleFatalError(this, "Unexpected Error!", err);
+            errorHandler.handleFatalError(
+                Thread.currentThread(),
+                "Unexpected Error!", err);
         }
         finally
         {

--- a/src/main/java/org/ice4j/stack/MessageProcessor.java
+++ b/src/main/java/org/ice4j/stack/MessageProcessor.java
@@ -127,6 +127,18 @@ class MessageProcessor
         this.rawMessageProcessedHandler = onProcessed;
     }
 
+    /**
+     * Performs proper reset of internal state of pooled instance.
+     */
+    public void resetState()
+    {
+        this.reinitialize();
+        this.cancelled.set(false);
+    }
+
+    /**
+     * Attempts to cancel processing of {@link #rawMessage}
+     */
     public void cancel()
     {
         this.cancelled.set(true);
@@ -185,6 +197,10 @@ class MessageProcessor
         }
         finally
         {
+            // On processed callback must be invoked in call cases, even when
+            // cancellation or early exist happen, otherwise
+            // NetAccessManager internal tracking of pooled and active objects
+            // will be confused.
             if (onProcessed != null)
             {
                 onProcessed.accept(this);

--- a/src/main/java/org/ice4j/stack/NetAccessManager.java
+++ b/src/main/java/org/ice4j/stack/NetAccessManager.java
@@ -58,8 +58,7 @@ class NetAccessManager
      * (UDP) also does not have such guarantee, so it is ok when some of the
      * messages will be processed out of arrival (enqueuing) order, but faster.
      */
-    private static ForkJoinPool messageProcessorExecutor
-        = new ForkJoinPool(Runtime.getRuntime().availableProcessors());
+    private static ForkJoinPool messageProcessorExecutor = new ForkJoinPool();
 
     /**
      * Pool of <tt>MessageProcessor</tt> objects to avoid extra-allocations of
@@ -199,7 +198,7 @@ class NetAccessManager
      * Gets the <tt>PeerUdpMessageEventHandler</tt> of this
      * <tt>NetAccessManager</tt> which is to be notified when incoming UDP
      * messages have been processed and are ready for delivery.
-     * 
+     *
      * @return the <tt>PeerUdpMessageEventHandler</tt> of this
      *         <tt>NetAccessManager</tt> which is to be notified when incoming
      *         UDP messages have been processed and are ready for delivery
@@ -213,7 +212,7 @@ class NetAccessManager
      * Gets the <tt>ChannelDataEventHandler</tt> of this
      * <tt>NetAccessManager</tt> which is to be notified when incoming
      * ChannelData messages have been processed and are ready for delivery.
-     * 
+     *
      * @return the <tt>ChannelDataEventHandler</tt> of this
      *         <tt>NetAccessManager</tt> which is to be notified when incoming
      *         ChannelData messages have been processed and are ready for

--- a/src/main/java/org/ice4j/stack/NetAccessManager.java
+++ b/src/main/java/org/ice4j/stack/NetAccessManager.java
@@ -52,11 +52,11 @@ class NetAccessManager
     /**
      * Thread pool to execute {@link MessageProcessor}s across all
      * {@link NetAccessManager}s.
-     * The work-stealing thread pool tries to utilizes all available processors
-     * in parallel, but does not have guarantee about the order of execution,
-     * but underlying transport (UDP) also does not have such guarantee,
-     * so it is ok when some of the messages will be processed out of
-     * arrival (enqueuing) order, but faster.
+     * The work-stealing thread pool {@link java.util.concurrent.ForkJoinPool}
+     * tries to utilizes all available processors in parallel, but does not
+     * have guarantee about the order of execution, but underlying transport
+     * (UDP) also does not have such guarantee, so it is ok when some of the
+     * messages will be processed out of arrival (enqueuing) order, but faster.
      */
     private static ForkJoinPool messageProcessorExecutor
         = new ForkJoinPool(Runtime.getRuntime().availableProcessors());
@@ -69,7 +69,9 @@ class NetAccessManager
         = new ArrayBlockingQueue<>(8);
 
     /**
-     * The set of <tt>Future</tt>'s of not yet processed <tt>RawMessage</tt>s
+     * The set of <tt>Future</tt>'s of not yet processed <tt>RawMessage</tt>s,
+     * this tracking is necessary to properly cancel pending tasks in case
+     * {@link #stop()} is called.
      */
     private final ConcurrentHashMap.KeySetView<MessageProcessor, Boolean>
         activeMessageProcessors = ConcurrentHashMap.newKeySet();

--- a/src/main/java/org/ice4j/stack/NetAccessManager.java
+++ b/src/main/java/org/ice4j/stack/NetAccessManager.java
@@ -521,7 +521,7 @@ class NetAccessManager
         }
         else
         {
-            messageProcessor.reinitialize();
+            messageProcessor.resetState();
         }
 
         messageProcessor.setMessage(

--- a/src/main/java/org/ice4j/stack/NetAccessManager.java
+++ b/src/main/java/org/ice4j/stack/NetAccessManager.java
@@ -484,7 +484,7 @@ class NetAccessManager
 
     /**
      * Enqueues incoming message
-     * @param message
+     * @param message <tt>RawMessage</tt> to process
      */
     private void onIncomingRawMessage(final RawMessage message)
     {

--- a/src/main/java/org/ice4j/stack/NetAccessManager.java
+++ b/src/main/java/org/ice4j/stack/NetAccessManager.java
@@ -227,7 +227,7 @@ class NetAccessManager
      * Gets the <tt>PeerUdpMessageEventHandler</tt> of this
      * <tt>NetAccessManager</tt> which is to be notified when incoming UDP
      * messages have been processed and are ready for delivery.
-     *
+     * 
      * @return the <tt>PeerUdpMessageEventHandler</tt> of this
      *         <tt>NetAccessManager</tt> which is to be notified when incoming
      *         UDP messages have been processed and are ready for delivery
@@ -241,7 +241,7 @@ class NetAccessManager
      * Gets the <tt>ChannelDataEventHandler</tt> of this
      * <tt>NetAccessManager</tt> which is to be notified when incoming
      * ChannelData messages have been processed and are ready for delivery.
-     *
+     * 
      * @return the <tt>ChannelDataEventHandler</tt> of this
      *         <tt>NetAccessManager</tt> which is to be notified when incoming
      *         ChannelData messages have been processed and are ready for

--- a/src/main/java/org/ice4j/stack/NetAccessManager.java
+++ b/src/main/java/org/ice4j/stack/NetAccessManager.java
@@ -273,7 +273,7 @@ class NetAccessManager
     @Override
     public void handleError(String message, Throwable error)
     {
-        if (this.isStopped.get())
+        if (isStopped.get())
         {
             logger.log(Level.WARNING,
                 "Got error when stopped, ignoring: " + message, error);
@@ -300,7 +300,7 @@ class NetAccessManager
                                  String message,
                                  Throwable error)
     {
-        if (this.isStopped.get())
+        if (isStopped.get())
         {
             logger.log(Level.WARNING,
                 "Got fatal error when stopped, ignoring: " + message, error);
@@ -464,7 +464,7 @@ class NetAccessManager
     {
         // Mark NetAccessManager as stopped, it will immediately result in
         // ignoring of all concurrent requests to handle messages
-        this.isStopped.set(true);
+        isStopped.set(true);
 
         // no item can be added to {@link #activeTasks} when
         // NetAccessManager is stopped, so it is safe to iterate without
@@ -542,7 +542,7 @@ class NetAccessManager
      */
     private void onIncomingRawMessage(final RawMessage message)
     {
-        if (this.isStopped.get())
+        if (isStopped.get())
         {
             logger.fine("Got RawMessage when stopped, ignore it.");
             return;

--- a/src/main/java/org/ice4j/stack/NetAccessManager.java
+++ b/src/main/java/org/ice4j/stack/NetAccessManager.java
@@ -544,7 +544,7 @@ class NetAccessManager
     {
         if (this.isStopped.get())
         {
-            logger.fine("Got RawMessage when stopping, ignoring.");
+            logger.fine("Got RawMessage when stopped, ignore it.");
             return;
         }
 

--- a/src/main/java/org/ice4j/stack/NetAccessManager.java
+++ b/src/main/java/org/ice4j/stack/NetAccessManager.java
@@ -55,8 +55,8 @@ class NetAccessManager
      * Thread pool to execute {@link MessageProcessingTask}s across all
      * {@link NetAccessManager}s.
      */
-    private static ForkJoinPool messageProcessingExecutor
-        = ExecutorFactory.createForkJoinPool(
+    private static ExecutorService messageProcessingExecutor
+        = ExecutorFactory.createFixedThreadPool(
             Runtime.getRuntime().availableProcessors(),
             "ice4j.NetAccessManager-");
 
@@ -534,10 +534,9 @@ class NetAccessManager
             message,
             onMessageProcessorProcessedRawMessage);
 
-        // Because MessageProcessingTask is ForkJoinTask<Void> it is not
-        // re-wrapped inside ForkJoinPool and no hidden allocation
-        // is done inside pool.
-        messageProcessingExecutor.submit(messageProcessingTask);
+        // Use overload which does not return Future object to avoid
+        // unnecessary allocation
+        messageProcessingExecutor.execute(messageProcessingTask);
     }
 
     //--------------- SENDING MESSAGES -----------------------------------------

--- a/src/main/java/org/ice4j/stack/NetAccessManager.java
+++ b/src/main/java/org/ice4j/stack/NetAccessManager.java
@@ -465,7 +465,7 @@ class NetAccessManager
         // ignoring of all concurrent requests to handle messages
         this.isStopped.set(true);
 
-        // no item can be added to {@link #unprocessedMessageFutures} when
+        // no item can be added to {@link #activeTasks} when
         // NetAccessManager is stopped, so it is safe to iterate without
         // removing item in-place.
         for (MessageProcessingTask messageProcessingTask : activeTasks)

--- a/src/main/java/org/ice4j/stack/NetAccessManager.java
+++ b/src/main/java/org/ice4j/stack/NetAccessManager.java
@@ -75,9 +75,9 @@ class NetAccessManager
         = new ArrayBlockingQueue<>(TASK_POOL_SIZE);
 
     /**
-     * The set of <tt>Future</tt>'s of not yet processed <tt>RawMessage</tt>s,
-     * this tracking is necessary to properly cancel pending tasks in case
-     * {@link #stop()} is called.
+     * The set of {@link MessageProcessingTask}'s which are not yet finished
+     * it's, processing, tracking of active tasks is necessary to properly
+     * cancel pending tasks in case {@link #stop()} is called.
      */
     private final ConcurrentHashMap.KeySetView<MessageProcessingTask, Boolean>
         activeTasks = ConcurrentHashMap.newKeySet();

--- a/src/main/java/org/ice4j/stack/NetAccessManager.java
+++ b/src/main/java/org/ice4j/stack/NetAccessManager.java
@@ -154,8 +154,9 @@ class NetAccessManager
      * Callback to be called when scheduled <tt>MessageProcessingTask</tt>
      * completes processing it's <tt>RawMessage</tt>.
      */
-    private final Consumer<MessageProcessingTask>
-        onMessageProcessorProcessedRawMessage = messageProcessingTask -> {
+    private final Consumer<MessageProcessingTask> onRawMessageProcessed
+        = messageProcessingTask -> {
+
         activeTasks.remove(messageProcessingTask);
 
         if (queueStatistics != null)
@@ -565,7 +566,7 @@ class NetAccessManager
 
         messageProcessingTask.setMessage(
             message,
-            onMessageProcessorProcessedRawMessage);
+            onRawMessageProcessed);
 
         activeTasks.add(messageProcessingTask);
 

--- a/src/main/java/org/ice4j/stack/NetAccessManager.java
+++ b/src/main/java/org/ice4j/stack/NetAccessManager.java
@@ -564,9 +564,7 @@ class NetAccessManager
             messageProcessingTask.resetState();
         }
 
-        messageProcessingTask.setMessage(
-            message,
-            onRawMessageProcessed);
+        messageProcessingTask.setMessage(message, onRawMessageProcessed);
 
         activeTasks.add(messageProcessingTask);
 

--- a/src/main/java/org/ice4j/stack/NetAccessManager.java
+++ b/src/main/java/org/ice4j/stack/NetAccessManager.java
@@ -536,7 +536,8 @@ class NetAccessManager
     }
 
     /**
-     * Enqueues incoming message
+     * Enqueues incoming {@link RawMessage} for asynchronous
+     * processing by {@link #messageProcessingExecutor}
      * @param message <tt>RawMessage</tt> to process
      */
     private void onIncomingRawMessage(final RawMessage message)

--- a/src/main/java/org/ice4j/stack/NetAccessManager.java
+++ b/src/main/java/org/ice4j/stack/NetAccessManager.java
@@ -32,11 +32,11 @@ import org.ice4j.socket.*;
 import org.ice4j.util.*;
 
 /**
- * Manages <tt>Connector</tt>s and <tt>MessageProcessingTask</tt> pooling. This
- * class serves as a layer that masks network primitives and provides equivalent
- * STUN abstractions. Instances that operate with the NetAccessManager are only
- * supposed to understand STUN talk and shouldn't be aware of datagrams sockets,
- * and etc.
+ * Manages <tt>Connector</tt>s and <tt>MessageProcessingTask</tt> execution and
+ * pooling. This class serves as a layer that masks network primitives and
+ * provides equivalent STUN abstractions. Instances that operate with
+ * the NetAccessManager are only supposed to understand STUN talk and
+ * shouldn't be aware of datagrams sockets, and etc.
  * 
  * @author Emil Ivov
  * @author Aakash Garg

--- a/src/main/java/org/ice4j/stack/NetAccessManager.java
+++ b/src/main/java/org/ice4j/stack/NetAccessManager.java
@@ -139,28 +139,9 @@ class NetAccessManager
      * processing it's <tt>RawMessage</tt>.
      */
     private final Consumer<MessageProcessor>
-        onMessageProcessorProcessedRawMessage = new Consumer<MessageProcessor>()
-    {
-        @Override
-        public void accept(MessageProcessor messageProcessor)
-        {
-            activeMessageProcessors.remove(messageProcessor);
-            messageProcessorsPool.offer(messageProcessor);
-        }
-    };
-
-    /**
-     * Callback to be passed into {@link Connector} to invoke when
-     * new {@link RawMessage} is received.
-     */
-    private final Consumer<RawMessage>
-        onIncomignRawMessage = new Consumer<RawMessage>()
-    {
-        @Override
-        public void accept(RawMessage rawMessage)
-        {
-            processIncomingRawMessage(rawMessage);
-        }
+        onMessageProcessorProcessedRawMessage = messageProcessor -> {
+        activeMessageProcessors.remove(messageProcessor);
+        messageProcessorsPool.offer(messageProcessor);
     };
 
     /**
@@ -386,7 +367,7 @@ class NetAccessManager
             if (!connectorsForLocalAddress.containsKey(remoteAddress))
             {
                 Connector connector
-                    = new Connector(socket, remoteAddress, onIncomignRawMessage, this);
+                    = new Connector(socket, remoteAddress, this::onIncomingRawMessage, this);
 
                 connectorsForLocalAddress.put(remoteAddress, connector);
                 connector.start();
@@ -521,10 +502,10 @@ class NetAccessManager
     }
 
     /**
-     * Enqueues incoming <tt>RawMessage</tt> for processing.
+     * Enqueues incoming message
      * @param message <tt>RawMessage</tt> to process
      */
-    private void processIncomingRawMessage(final RawMessage message)
+    private void onIncomingRawMessage(final RawMessage message)
     {
         if (this.isStopped.get())
         {

--- a/src/main/java/org/ice4j/stack/NetAccessManager.java
+++ b/src/main/java/org/ice4j/stack/NetAccessManager.java
@@ -149,14 +149,12 @@ class NetAccessManager
         onMessageProcessorProcessedRawMessage = messageProcessingTask -> {
         activeTasks.remove(messageProcessingTask);
 
-        if (!taskPool.offer(messageProcessingTask))
+        final boolean isAdded = taskPool.offer(messageProcessingTask);
+        if (!isAdded && logger.isLoggable(Level.FINEST))
         {
-            if (logger.isLoggable(Level.FINEST))
-            {
-                logger.finest("Dropping MessageProcessingTask for "
-                    + this + " because pool is full, max pool size is "
-                    + String.valueOf(TASK_POOL_SIZE));
-            }
+            logger.finest("Dropping MessageProcessingTask for "
+                + this + " because pool is full, max pool size is "
+                + String.valueOf(TASK_POOL_SIZE));
         }
     };
 
@@ -555,6 +553,7 @@ class NetAccessManager
             message,
             onMessageProcessorProcessedRawMessage);
 
+        activeTasks.add(messageProcessingTask);
         // Use overload which does not return Future object to avoid
         // unnecessary allocation
         messageProcessingExecutor.execute(messageProcessingTask);

--- a/src/main/java/org/ice4j/stack/NetAccessManager.java
+++ b/src/main/java/org/ice4j/stack/NetAccessManager.java
@@ -41,6 +41,7 @@ import org.ice4j.util.*;
  * @author Emil Ivov
  * @author Aakash Garg
  * @author Boris Grozev
+ * @author Yura Yaroshevich
  */
 class NetAccessManager
     implements ErrorHandler

--- a/src/main/java/org/ice4j/stack/NetAccessManager.java
+++ b/src/main/java/org/ice4j/stack/NetAccessManager.java
@@ -24,10 +24,12 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 import java.util.function.*;
 import java.util.logging.*;
+import java.util.logging.Logger; // Disambiguation
 
 import org.ice4j.*;
 import org.ice4j.message.*;
 import org.ice4j.socket.*;
+import org.ice4j.util.*;
 
 /**
  * Manages <tt>Connector</tt>s and <tt>MessageProcessingTask</tt> pooling. This
@@ -52,13 +54,11 @@ class NetAccessManager
     /**
      * Thread pool to execute {@link MessageProcessingTask}s across all
      * {@link NetAccessManager}s.
-     * The work-stealing thread pool {@link java.util.concurrent.ForkJoinPool}
-     * tries to utilizes all available processors in parallel, but does not
-     * have guarantee about the order of execution, but underlying transport
-     * (UDP) also does not have such guarantee, so it is ok when some of the
-     * messages will be processed out of arrival (enqueuing) order, but faster.
      */
-    private static ForkJoinPool messageProcessingExecutor = new ForkJoinPool();
+    private static ForkJoinPool messageProcessingExecutor
+        = ExecutorFactory.createForkJoinPool(
+            Runtime.getRuntime().availableProcessors(),
+            "ice4j.NetAccessManager-");
 
     /**
      * Pool of <tt>MessageProcessingTask</tt> objects to avoid extra-allocations

--- a/src/main/java/org/ice4j/stack/StunStack.java
+++ b/src/main/java/org/ice4j/stack/StunStack.java
@@ -942,7 +942,6 @@ public class StunStack
                             ev.getLocalAddress(),
                             ev.getRemoteAddress());
 
-                // TODO: Consider remove this try/catch because.
                 // if there is an OOM error here, it will lead to
                 // NetAccessManager.handleFatalError that will stop the
                 // MessageProcessingTask thread and restart it that will lead

--- a/src/main/java/org/ice4j/stack/StunStack.java
+++ b/src/main/java/org/ice4j/stack/StunStack.java
@@ -44,12 +44,6 @@ import org.ice4j.util.*;
 public class StunStack
     implements MessageEventHandler
 {
-
-    /**
-     * The number of threads to split our flow in.
-     */
-    public static final int DEFAULT_THREAD_POOL_SIZE = 3;
-
     /**
      * The <tt>Logger</tt> used by the <tt>StunStack</tt> class and its
      * instances for logging output.
@@ -118,18 +112,6 @@ public class StunStack
      * The packet logger instance.
      */
     private static PacketLogger packetLogger;
-
-    /**
-     * Sets the number of Message processors running in the same time.
-     *
-     * @param threadPoolSize the number of message process threads to run.
-     * @throws IllegalArgumentException if threadPoolSize is not a valid size.
-     */
-    public void setThreadPoolSize(int threadPoolSize)
-        throws IllegalArgumentException
-    {
-        netAccessManager.setThreadPoolSize(threadPoolSize);
-    }
 
     /**
      * Creates and starts a Network Access Point (Connector) based on the

--- a/src/main/java/org/ice4j/stack/StunStack.java
+++ b/src/main/java/org/ice4j/stack/StunStack.java
@@ -942,10 +942,7 @@ public class StunStack
                             ev.getLocalAddress(),
                             ev.getRemoteAddress());
 
-                // if there is an OOM error here, it will lead to
-                // NetAccessManager.handleFatalError that will stop the
-                // MessageProcessingTask thread and restart it that will lead
-                // again to an OOM error and so on... So stop here right now
+                // if there is an OOM error here, stop here right now
                 try
                 {
                     sTran.start();

--- a/src/main/java/org/ice4j/stack/StunStack.java
+++ b/src/main/java/org/ice4j/stack/StunStack.java
@@ -942,10 +942,11 @@ public class StunStack
                             ev.getLocalAddress(),
                             ev.getRemoteAddress());
 
+                // TODO: Consider remove this try/catch because.
                 // if there is an OOM error here, it will lead to
                 // NetAccessManager.handleFatalError that will stop the
-                // MessageProcessor thread and restart it that will lead again
-                // to an OOM error and so on... So stop here right now
+                // MessageProcessingTask thread and restart it that will lead
+                // again to an OOM error and so on... So stop here right now
                 try
                 {
                     sTran.start();

--- a/src/main/java/org/ice4j/util/ExecutorFactory.java
+++ b/src/main/java/org/ice4j/util/ExecutorFactory.java
@@ -112,4 +112,30 @@ public class ExecutorFactory
         executor.setRemoveOnCancelPolicy(true);
         return Executors.unconfigurableScheduledExecutorService(executor);
     }
+
+
+    /**
+     * Creates a {@link ForkJoinPool} with the given parameters.
+     *
+     * @param parallelism the parallelism level. For default value,
+     * use {@link java.lang.Runtime#availableProcessors}.
+     * @param threadNamePrefix - name prefix for threads created by pool
+     */
+    public static ForkJoinPool createForkJoinPool(
+        int parallelism, String threadNamePrefix)
+    {
+        final ForkJoinPool.ForkJoinWorkerThreadFactory threadFactory = pool ->
+        {
+            final ForkJoinWorkerThread thread
+                = ForkJoinPool
+                    .defaultForkJoinWorkerThreadFactory
+                    .newThread(pool);
+            if (threadNamePrefix != null)
+            {
+                thread.setName(threadNamePrefix + thread.getName());
+            }
+            return thread;
+        };
+        return new ForkJoinPool(parallelism, threadFactory, null, false);
+    }
 }

--- a/src/main/java/org/ice4j/util/ExecutorFactory.java
+++ b/src/main/java/org/ice4j/util/ExecutorFactory.java
@@ -22,6 +22,8 @@ import java.util.concurrent.*;
 
 /**
  * Helper class which contains functions to create pre-configured executors
+ *
+ * @author Yura Yaroshevich
  */
 public class ExecutorFactory
 {

--- a/src/main/java/org/ice4j/util/ExecutorFactory.java
+++ b/src/main/java/org/ice4j/util/ExecutorFactory.java
@@ -138,4 +138,27 @@ public class ExecutorFactory
         };
         return new ForkJoinPool(parallelism, threadFactory, null, false);
     }
+
+    /**
+     * Creates a {@link ExecutorService} with limited number of threads which
+     * are released after idle timeout.
+     *
+     * @param threadsLimit - numbers of threads in pool
+     * @param threadNamePrefix - name prefix for threads created by pool
+     * @return pre-configured {@link ExecutorService}
+     */
+    public static ExecutorService createFixedThreadPool(
+        int threadsLimit,
+        String threadNamePrefix)
+    {
+        final CustomizableThreadFactory threadFactory
+            = new CustomizableThreadFactory(threadNamePrefix, true);
+
+        final ThreadPoolExecutor executor = new ThreadPoolExecutor(
+            threadsLimit, threadsLimit,60L, TimeUnit.SECONDS,
+            new LinkedBlockingDeque<>(), threadFactory);
+        executor.allowCoreThreadTimeOut(true);
+
+        return Executors.unconfigurableExecutorService(executor);
+    }
 }

--- a/src/main/java/org/ice4j/util/ExecutorFactory.java
+++ b/src/main/java/org/ice4j/util/ExecutorFactory.java
@@ -113,32 +113,6 @@ public class ExecutorFactory
         return Executors.unconfigurableScheduledExecutorService(executor);
     }
 
-
-    /**
-     * Creates a {@link ForkJoinPool} with the given parameters.
-     *
-     * @param parallelism the parallelism level. For default value,
-     * use {@link java.lang.Runtime#availableProcessors}.
-     * @param threadNamePrefix - name prefix for threads created by pool
-     */
-    public static ForkJoinPool createForkJoinPool(
-        int parallelism, String threadNamePrefix)
-    {
-        final ForkJoinPool.ForkJoinWorkerThreadFactory threadFactory = pool ->
-        {
-            final ForkJoinWorkerThread thread
-                = ForkJoinPool
-                    .defaultForkJoinWorkerThreadFactory
-                    .newThread(pool);
-            if (threadNamePrefix != null)
-            {
-                thread.setName(threadNamePrefix + thread.getName());
-            }
-            return thread;
-        };
-        return new ForkJoinPool(parallelism, threadFactory, null, false);
-    }
-
     /**
      * Creates a {@link ExecutorService} with limited number of threads which
      * are released after idle timeout.

--- a/src/main/java/org/ice4j/util/ExecutorFactory.java
+++ b/src/main/java/org/ice4j/util/ExecutorFactory.java
@@ -155,7 +155,7 @@ public class ExecutorFactory
             = new CustomizableThreadFactory(threadNamePrefix, true);
 
         final ThreadPoolExecutor executor = new ThreadPoolExecutor(
-            threadsLimit, threadsLimit,60L, TimeUnit.SECONDS,
+            threadsLimit, threadsLimit, 60L, TimeUnit.SECONDS,
             new LinkedBlockingDeque<>(), threadFactory);
         executor.allowCoreThreadTimeOut(true);
 


### PR DESCRIPTION
It is observed in test environment that `ice4j` creates too many `Stun4J Message Processor` threads.

When there are `C` conferences each with `P` peers, then under the hood `C * P * 3 (default value)` threads were created to decode and process stun messages.
So, when there are `30` conferences `3` peers each there was `270` threads created to process stun messages.

All these threads were replaced with single `ForkJoinPool`.

Java version was also updated to 1.8, because I've used some of 1.8's API to reduce threads usage. Rest of Jitsi's repositories seem to be already migrated to 1.8, so I hope it is not a problem that I've updated version. for `ice4j`.
Permission of migration to Java 8 has been confirmed by Ingo Bauersachs.