### PR TITLE
Do not limit org.ice4j.ice.harvest.DISABLE_LINK_LOCAL_ADDRESSES to IPv6.

### DIFF
--- a/src/main/java/org/ice4j/StackProperties.java
+++ b/src/main/java/org/ice4j/StackProperties.java
@@ -220,7 +220,7 @@ public class StackProperties
             = "org.ice4j.ice.harvest.ALLOWED_ADDRESSES";
 
     /**
-     * The name of the property which, if set to true, specifies that IPv6
+     * The name of the property which, if set to true, specifies that
      * link local addresses should not be used for candidate allocations.
      */
     public static final String DISABLE_LINK_LOCAL_ADDRESSES

--- a/src/main/java/org/ice4j/ice/harvest/AbstractTcpListener.java
+++ b/src/main/java/org/ice4j/ice/harvest/AbstractTcpListener.java
@@ -286,7 +286,7 @@ public abstract class AbstractTcpListener
         boolean useIPv6 = !StackProperties.getBoolean(
                 StackProperties.DISABLE_IPv6,
                 false);
-        boolean useIPv6LinkLocal = !StackProperties.getBoolean(
+        boolean useLinkLocalAddresses = !StackProperties.getBoolean(
                 StackProperties.DISABLE_LINK_LOCAL_ADDRESSES,
                 false);
 
@@ -335,8 +335,7 @@ public abstract class AbstractTcpListener
             if (!useIPv6 && (address instanceof Inet6Address))
                 continue;
 
-            if (!useIPv6LinkLocal
-                    && (address instanceof Inet6Address)
+            if (!useLinkLocalAddresses
                     && address.isLinkLocalAddress())
             {
                 logger.info("Not using link-local address " + address +" for"

--- a/src/main/java/org/ice4j/ice/harvest/HostCandidateHarvester.java
+++ b/src/main/java/org/ice4j/ice/harvest/HostCandidateHarvester.java
@@ -232,7 +232,7 @@ public class HostCandidateHarvester
         boolean isIPv6Disabled = StackProperties.getBoolean(
                 StackProperties.DISABLE_IPv6,
                 false);
-        boolean isIPv6LinkLocalDisabled = StackProperties.getBoolean(
+        boolean isLinkLocalAddressesDisabled = StackProperties.getBoolean(
                 StackProperties.DISABLE_LINK_LOCAL_ADDRESSES,
                 false);
 
@@ -259,8 +259,7 @@ public class HostCandidateHarvester
 
                     if (isIPv6Disabled && address instanceof Inet6Address)
                         continue;
-                    if (isIPv6LinkLocalDisabled
-                            && address instanceof Inet6Address
+                    if (isLinkLocalAddressesDisabled
                             && address.isLinkLocalAddress())
                         continue;
 
@@ -316,7 +315,7 @@ public class HostCandidateHarvester
                 StackProperties.DISABLE_IPv6,
                 false);
 
-        boolean isIPv6LinkLocalDisabled = StackProperties.getBoolean(
+        boolean isLinkLocalAddressesDisabled = StackProperties.getBoolean(
                 StackProperties.DISABLE_LINK_LOCAL_ADDRESSES,
                 false);
 
@@ -353,8 +352,7 @@ public class HostCandidateHarvester
                     continue;
                 }
 
-                if (isIPv6LinkLocalDisabled
-                        && (addr instanceof Inet6Address)
+                if (isLinkLocalAddressesDisabled
                         && addr.isLinkLocalAddress())
                 {
                     continue;


### PR DESCRIPTION
When link local addresses disabled via setting `org.ice4j.ice.harvest.DISABLE_LINK_LOCAL_ADDRESSES = true` it only disabled IPv6 link-local addresses. 
On some environments like Mac and Windows (with virtual Hyper-V networks adapters) there are link local network interfaces with IPv4 addresses, but they can not be filtered via `org.ice4j.ice.harvest.DISABLE_LINK_LOCAL_ADDRESSES `.
This PR fixes this and filter both IPv6 and IPv6 local addresses.
Relevant brief discussion on [community.jitsi.org](https://community.jitsi.org/t/why-ipv4-link-local-addresses-are-not-disabled-by-disable-link-local-addresses-setting/15683/)