### PR TITLE
Do not explicitly create threads in PacketQueue

### DIFF
--- a/src/main/java/org/ice4j/util/AsyncQueueHandler.java
+++ b/src/main/java/org/ice4j/util/AsyncQueueHandler.java
@@ -112,14 +112,14 @@ public final class AsyncQueueHandler<T>
 
             while (running.get())
             {
-                T item;
-
                 if (maxSequentiallyHandledItems > 0 &&
                     sequentiallyHandledItems >= maxSequentiallyHandledItems)
                 {
                     onYield();
                     return;
                 }
+
+                T item;
 
                 synchronized (syncRoot)
                 {

--- a/src/main/java/org/ice4j/util/AsyncQueueHandler.java
+++ b/src/main/java/org/ice4j/util/AsyncQueueHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright @ 2018 Jitsi.org
+ * Copyright @ 2018 8x8, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ice4j/util/AsyncQueueHandler.java
+++ b/src/main/java/org/ice4j/util/AsyncQueueHandler.java
@@ -235,6 +235,16 @@ public final class AsyncQueueHandler<T>
         String id,
         ExecutorService executor)
     {
+        if (queue == null)
+        {
+            throw new IllegalArgumentException("queue is null");
+        }
+
+        if (handler == null)
+        {
+            throw new IllegalArgumentException("handler is null");
+        }
+
         this.executor = executor != null ? executor : sharedExecutor;
         this.queue = queue;
         this.handler = handler;

--- a/src/main/java/org/ice4j/util/AsyncQueueHandler.java
+++ b/src/main/java/org/ice4j/util/AsyncQueueHandler.java
@@ -211,14 +211,12 @@ public final class AsyncQueueHandler<T>
     /**
      * Invoked when execution of {@link #reader} is about to temporary
      * cancel and further execution need to be re-scheduled.
-     * Assuming called when lock on {@link #syncRoot} is already taken.
      */
     private void onYield()
     {
         if (logger.isLoggable(java.util.logging.Level.FINE))
         {
-            logger.fine("Yielding AsyncQueueHandler associated with "
-                + "AsyncQueueHandler with ID = " + id);
+            logger.fine("Yielding AsyncQueueHandler with ID = " + id);
         }
 
         synchronized (syncRoot)
@@ -229,8 +227,7 @@ public final class AsyncQueueHandler<T>
     }
 
     /**
-     * Attempts to cancel currently running reader. Assuming called when
-     * lock on {@link #syncRoot} is already taken
+     * Attempts to cancel currently running reader.
      * @param mayInterruptIfRunning indicates if {@link #reader} allowed
      * to be interrupted if running
      */

--- a/src/main/java/org/ice4j/util/AsyncQueueHandler.java
+++ b/src/main/java/org/ice4j/util/AsyncQueueHandler.java
@@ -240,7 +240,6 @@ public final class AsyncQueueHandler<T>
 
         synchronized (syncRoot)
         {
-            cancel(false);
             readerFuture = executor.submit(reader);
         }
     }

--- a/src/main/java/org/ice4j/util/AsyncQueueHandler.java
+++ b/src/main/java/org/ice4j/util/AsyncQueueHandler.java
@@ -1,0 +1,448 @@
+/*
+ * Copyright @ 2018 Jitsi.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ice4j.util;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
+
+/**
+ * Asynchronously reads items from provided {@link #queue} on separate thread
+ * borrowed from {@link #executor} and process items with specified handler.
+ * Thread is not blocked when queue is empty and returned back to
+ * {@link #executor} pool. New or existing thread is borrowed from
+ * {@link #executor} when queue is non empty and {@link #reader} is not
+ * running
+ *
+ * @author Yura Yaroshevich
+ */
+public final class AsyncQueueHandler<T>
+{
+    /**
+     * The {@link java.util.logging.Logger} used by the
+     * {@link AsyncQueueHandler} class and its instances for logging output.
+     */
+    private static final java.util.logging.Logger logger
+        = Logger.getLogger(AsyncQueueHandler.class.getName());
+
+    /**
+     * ScheduledExecutorService to implement delay during throttling in
+     * <tt>AsyncQueueHandler</tt>
+     */
+    private final static ScheduledExecutorService delayTimer
+        = Executors.newSingleThreadScheduledExecutor(
+            new CustomizableThreadFactory(
+                AsyncQueueHandler.class.getName() + "-timer-", true));
+
+    /**
+     * The default <tt>ExecutorService</tt> to run <tt>AsyncQueueHandler</tt>
+     * when there is no executor injected in constructor.
+     */
+    private final static ExecutorService sharedExecutor
+        = Executors.newCachedThreadPool(
+            new CustomizableThreadFactory(
+                AsyncQueueHandler.class.getName() + "-executor-", true));
+
+    /**
+     * Number of nanoseconds to consider queue is empty to exit reading loop in
+     * borrowed thread.
+     */
+    private final static long emptyQueueTimeoutNanoseconds = 50;
+
+    /**
+     * Executor service to run <tt>AsyncQueueHandler</tt>, which asynchronously
+     * invokes specified {@link #handler} on queued items.
+     */
+    private final ExecutorService executor;
+
+    /**
+     * An {@link BlockingQueue <T>} which will be read on separate thread.
+     */
+    private final BlockingQueue<T> queue;
+
+    /**
+     * The {@link Handler<T>} used to handle items read from
+     * {@link #queue} by {@link #reader}.
+     */
+    private final Handler<T> handler;
+
+    /**
+     * An identifier of current reader which is used for debugging purpose.
+     */
+    private final String id;
+
+    /**
+     * A flag which indicates if reading of {@link #queue} should be
+     * cancelled.
+     */
+    private final AtomicBoolean cancelled = new AtomicBoolean();
+
+    /**
+     * Synchronization object of current instance state, in particular
+     * used to resolve races between {@link #handleQueueItemsUntilEmpty()}
+     * and {@link #reader} exit. In particular synchronization object used to
+     * access to field {@link #readerFuture} and {@link #delayedFuture}.
+     */
+    private final Object syncRoot = new Object();
+
+    /**
+     * Throttle calculator which is used for counting handled items and
+     * computing necessary delay before processing next item when
+     * throttling is enabled.
+     */
+    private final ThrottleCalculator<T> throttler;
+
+    /**
+     * Stores <tt>Future</tt> of currently executing {@link #reader}
+     */
+    private Future<?> readerFuture;
+
+    /**
+     * Stores <tt>ScheduledFuture</tt> of currently delayed
+     * execution {@link #reader}
+     */
+    private ScheduledFuture<?> delayedFuture;
+
+    /**
+     * Perpetually reads item from {@link #queue} and uses
+     * {@link #handler} on each of them.
+     */
+    private final Runnable reader = new Runnable()
+    {
+        @Override
+        public void run()
+        {
+            final long maxSequentiallyHandledItems =
+                handler.maxSequentiallyHandledItems();
+
+            int sequentiallyHandledItems = 0;
+
+            while (!cancelled.get())
+            {
+                T pkt;
+
+                synchronized (syncRoot)
+                {
+                    long delay = throttler.getDelayNanos();
+                    if (delay > 0)
+                    {
+                        onDelay(delay, TimeUnit.NANOSECONDS);
+                        return;
+                    }
+
+                    if (maxSequentiallyHandledItems > 0 &&
+                        sequentiallyHandledItems >= maxSequentiallyHandledItems)
+                    {
+                        /*
+                        All instances of AsyncQueueHandler executed on
+                        single shared instance of ExecutorService to better
+                        use existing threads and to reduce number of idle
+                        threads when reader's queue is empty.
+
+                        Having limited number of threads to execute might
+                        lead to other problem, when queue is always
+                        non-empty reader will keep running, while other
+                        readers might suffer from execution starvation. One
+                        way to solve this, is to to artificially interrupt
+                        current reader execution and pump it via internal
+                        executor's queue.
+                        */
+                        onYield();
+                        return;
+                    }
+
+                    try
+                    {
+                        // It is observed that giving very small poll timeout,
+                        // up to hundred nanoseconds, compared to not
+                        // timeout at all has about 5-10% better
+                        // performance in micro-benchmark scenarios.
+                        pkt = queue.poll(
+                            emptyQueueTimeoutNanoseconds, TimeUnit.NANOSECONDS);
+                    }
+                    catch (InterruptedException e)
+                    {
+                        pkt = null;
+                    }
+
+                    if (pkt == null)
+                    {
+                        cancel(false);
+                        return;
+                    }
+                }
+
+                sequentiallyHandledItems++;
+                throttler.notifyItemHandled();
+
+                try
+                {
+                    handler.handleItem(pkt);
+                }
+                catch (Throwable e)
+                {
+                    logger.warning("Failed to handle item: " + e);
+                }
+            }
+        }
+    };
+
+    /**
+     * Runnable which is scheduled with delay to perform actual
+     * scheduling of {@link #reader} execution.
+     */
+    private final Runnable delayedSchedule = new Runnable()
+    {
+        @Override
+        public void run()
+        {
+            synchronized (syncRoot)
+            {
+                delayedFuture = null;
+            }
+            handleQueueItemsUntilEmpty();
+        }
+    };
+
+    /**
+     * Constucts instance of {@link AsyncQueueHandler<T>} which is capable of
+     * asyncronous reading provided queue from thread borrowed from executor to
+     * process items with provided handler.
+     * @param queue host queue which holds items to process
+     * @param handler an implementation of handler routine which will be
+     *                invoked per each item placed in the queue.
+     * @param id optional identifier of current handler for debug purpose
+     * @param executor optional executor service to borrow threads from
+     */
+    public AsyncQueueHandler(
+        BlockingQueue<T> queue,
+        Handler<T> handler,
+        String id,
+        ExecutorService executor)
+    {
+        this.executor = executor != null ? executor : sharedExecutor;
+        this.queue = queue;
+        this.handler = handler;
+        this.id = id;
+        this.throttler = new ThrottleCalculator<>(handler);
+    }
+
+    /**
+     * Attempts to stop execution of {@link #reader} if running
+     */
+    public void cancel()
+    {
+        cancelled.set(true);
+
+        synchronized (syncRoot)
+        {
+            cancel(true);
+        }
+    }
+
+    /**
+     * Checks if {@link #reader} is running on one of {@link #executor}
+     * thread and if no submits execution of {@link #reader} on executor.
+     */
+    public void handleQueueItemsUntilEmpty()
+    {
+        if (cancelled.get())
+        {
+            return;
+        }
+
+        if (handler == null)
+        {
+            logger.warning("No handler set, the reading will not start.");
+            return;
+        }
+
+        synchronized (syncRoot)
+        {
+            if ((readerFuture == null || readerFuture.isDone())
+                && (delayedFuture == null || delayedFuture.isDone()))
+            {
+                readerFuture = executor.submit(reader);
+            }
+        }
+    }
+
+    /**
+     * Invoked when execution of {@link #reader} is about to temporary
+     * cancel and further execution need to be re-scheduled.
+     * Assuming called when lock on {@link #syncRoot} is already taken.
+     */
+    private void onYield()
+    {
+        logger.fine("Yielding AsyncQueueHandler associated with "
+            + "AsyncQueueHandler with ID = " + id);
+        cancel(false);
+        readerFuture = executor.submit(reader);
+    }
+
+    /**
+     * Invoked when next execution of {@link #reader} should be delayed.
+     * Assuming called when lock on {@link #syncRoot} is already taken.
+     * @param delay the time from now to delay execution
+     * @param unit the time unit of the delay parameter
+     */
+    private void onDelay(long delay, TimeUnit unit)
+    {
+        logger.fine("Delaying AsyncQueueHandler associated with "
+            + "AsyncQueueHandler with ID = " + id + " for "
+            + unit.toNanos(delay) + "us");
+        cancel(false);
+        delayedFuture = delayTimer.schedule(delayedSchedule, delay, unit);
+    }
+
+    /**
+     * Attempts to cancel currently running reader. Assuming called when
+     * lock on {@link #syncRoot} is already taken
+     * @param mayInterruptIfRunning indicates if {@link #reader} allowed
+     * to be interrupted if running
+     */
+    private void cancel(boolean mayInterruptIfRunning)
+    {
+        if (delayedFuture != null)
+        {
+            delayedFuture.cancel(mayInterruptIfRunning);
+            delayedFuture = null;
+        }
+
+        if (readerFuture != null)
+        {
+            readerFuture.cancel(mayInterruptIfRunning);
+            readerFuture = null;
+        }
+    }
+
+    /**
+     * A simple interface to handle enqueued {@link T} items.
+     * @param <T> the type of the item.
+     */
+    public interface Handler<T>
+    {
+        /**
+         * Does something with an item.
+         * @param item the item to do something with.
+         */
+        void handleItem(T item);
+
+        /**
+         * Specifies max number {@link #handleItem(T)} invocation
+         * per {@link #perNanos()}
+         * @return positive number of allowed handled items in case of
+         * throttling must be enabled.
+         */
+        default long maxHandledItems() {
+            return -1;
+        }
+
+        /**
+         * Specifies time interval in nanoseconds for {@link #maxHandledItems()}
+         * @return positive nanoseconds count in case of throttling must be
+         * enabled.
+         */
+        default long perNanos() {
+            return -1;
+        }
+
+        /**
+         * Specifies the number of items allowed to be handled sequentially
+         * without yielding control to executor's thread. Specifying positive
+         * number will allow other possible queues sharing same
+         * {@link ExecutorService} to process their items.
+         * @return positive value to specify max number of sequentially handled
+         * items which allows implementation of cooperative multi-tasking
+         * between different {@link AsyncQueueHandler<T>} sharing
+         * same {@link ExecutorService}.
+         */
+        default long maxSequentiallyHandledItems()
+        {
+            return -1;
+        }
+    }
+
+    /**
+     * Helper class to calculate throttle delay when throttling is enabled.
+     */
+    private static final class ThrottleCalculator<T>
+    {
+        /**
+         * The number of {@link T}s already processed during the current
+         * <tt>perNanos</tt> interval.
+         */
+        private long itemsHandledWithinInterval = 0;
+
+        /**
+         * The time stamp in nanoseconds of the start of the current
+         * <tt>perNanos</tt> interval.
+         */
+        private long intervalStartTimeNanos = 0;
+
+        /**
+         * {@link Handler <T>} instance which provide throttling
+         * configuration
+         */
+        private final Handler<T> handler;
+
+        ThrottleCalculator(Handler<T> handler)
+        {
+            if (handler == null)
+            {
+                throw new IllegalArgumentException("handler must not be null");
+            }
+            this.handler = handler;
+        }
+
+        /**
+         * Calculate necessary delay based current time and number of items
+         * processed during current time interval
+         * @return 0 in case delay is not necessary or delay value in nanos
+         */
+        long getDelayNanos()
+        {
+            final long perNanos = handler.perNanos();
+            final long maxHandledItems = handler.maxHandledItems();
+
+            if (perNanos > 0 && maxHandledItems > 0)
+            {
+                final long now = System.nanoTime();
+                final long nanosRemainingTime = now - intervalStartTimeNanos;
+
+                if (nanosRemainingTime >= perNanos)
+                {
+                    intervalStartTimeNanos = now;
+                    itemsHandledWithinInterval = 0;
+                }
+                else if (itemsHandledWithinInterval >= maxHandledItems)
+                {
+                    return nanosRemainingTime;
+                }
+            }
+            return 0;
+        }
+
+        /**
+         * Count number of handled items
+         */
+        void notifyItemHandled()
+        {
+            itemsHandledWithinInterval++;
+        }
+    }
+}

--- a/src/main/java/org/ice4j/util/AsyncQueueHandler.java
+++ b/src/main/java/org/ice4j/util/AsyncQueueHandler.java
@@ -147,8 +147,27 @@ public final class AsyncQueueHandler<T>
     };
 
     /**
-     * Constucts instance of {@link AsyncQueueHandler<T>} which is capable of
-     * asyncronous reading provided queue from thread borrowed from executor to
+     * Constructs instance of {@link AsyncQueueHandler<T>} which is capable of
+     * asynchronous reading provided queue from thread borrowed from executor to
+     * process items with provided handler.
+     * @param queue thread-safe queue which holds items to process
+     * @param handler an implementation of handler routine which will be
+     * invoked per each item placed in the queue.
+     * @param id optional identifier of current handler for debug purpose
+     * @param executor optional executor service to borrow threads from
+     */
+    public AsyncQueueHandler(
+        BlockingQueue<T> queue,
+        Handler<T> handler,
+        String id,
+        ExecutorService executor)
+    {
+        this(queue, handler, id, executor, -1);
+    }
+
+    /**
+     * Constructs instance of {@link AsyncQueueHandler<T>} which is capable of
+     * asynchronous reading provided queue from thread borrowed from executor to
      * process items with provided handler.
      * @param queue thread-safe queue which holds items to process
      * @param handler an implementation of handler routine which will be

--- a/src/main/java/org/ice4j/util/AsyncQueueHandler.java
+++ b/src/main/java/org/ice4j/util/AsyncQueueHandler.java
@@ -17,8 +17,8 @@
 package org.ice4j.util;
 
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Logger;
+import java.util.concurrent.atomic.*;
+import java.util.logging.Logger; // Disambiguation
 
 /**
  * Asynchronously reads items from provided {@link #queue} on separate thread

--- a/src/main/java/org/ice4j/util/PacketQueue.java
+++ b/src/main/java/org/ice4j/util/PacketQueue.java
@@ -47,11 +47,6 @@ public abstract class PacketQueue<T>
     private final static int DEFAULT_CAPACITY = 256;
 
     /**
-     * The capacity of the {@code byte[]} cache, if it is enabled.
-     */
-    private final static int CACHE_CAPACITY = 100;
-
-    /**
      * ScheduledExecutorService to implement delay during throttling in
      * <tt>AsyncPacketReader</tt>
      */
@@ -66,15 +61,6 @@ public abstract class PacketQueue<T>
         = Executors.newCachedThreadPool(
             new CustomizableThreadFactory(
                 "PacketQueue-", true));
-
-    /**
-     * Maximum number of packets processed in row before temporary stop
-     * reader execution to give possible other users of same {@link #executor}
-     * to proceed their execution. This mode of execution, when task is
-     * temporary stopped itself to give a chance to other tasks sharing same
-     * executor to run is called cooperative multi-tasking.
-     */
-    private final static int MAX_HANDLED_PACKETS_BEFORE_YIELD = 50;
 
     /**
      * Returns true if a warning should be logged after a queue has dropped

--- a/src/main/java/org/ice4j/util/PacketQueue.java
+++ b/src/main/java/org/ice4j/util/PacketQueue.java
@@ -663,7 +663,7 @@ public abstract class PacketQueue<T>
                         }
 
                         if (maxSequentiallyProcessedPackets > 0 &&
-                            handledPackets > maxSequentiallyProcessedPackets)
+                            handledPackets >= maxSequentiallyProcessedPackets)
                         {
                             onYield();
                             return;

--- a/src/main/java/org/ice4j/util/PacketQueue.java
+++ b/src/main/java/org/ice4j/util/PacketQueue.java
@@ -427,6 +427,18 @@ public abstract class PacketQueue<T>
         byte[] buf, int off, int len, Object context);
 
     /**
+     * Releases packet when it is handled by provided {@link #handler}.
+     * This method is not called when <tt>PacketQueue</tt> was created without
+     * {@link #handler} and hence no automatic queue processing is done.
+     * Default implementation is empty, but it might be used to impalement
+     * packet pooling to re-use them.
+     * @param pkt packet to release
+     */
+    protected void releasePacket(T pkt)
+    {
+    }
+
+    /**
      * A simple interface to handle packets.
      * @param <T> the type of the packets.
      */
@@ -518,6 +530,10 @@ public abstract class PacketQueue<T>
                     catch (Exception e)
                     {
                         logger.warning("Failed to handle packet: " + e);
+                    }
+                    finally
+                    {
+                        releasePacket(pkt);
                     }
                 }
             }

--- a/src/main/java/org/ice4j/util/PacketQueue.java
+++ b/src/main/java/org/ice4j/util/PacketQueue.java
@@ -566,7 +566,7 @@ public abstract class PacketQueue<T>
         {
             if (handler == null)
             {
-                return Long.MAX_VALUE;
+                return 0;
             }
 
             final long perNanos = handler.perNanos();

--- a/src/main/java/org/ice4j/util/PacketQueue.java
+++ b/src/main/java/org/ice4j/util/PacketQueue.java
@@ -60,7 +60,7 @@ public abstract class PacketQueue<T>
     private final static ExecutorService sharedExecutor
         = Executors.newCachedThreadPool(
             new CustomizableThreadFactory(
-                "PacketQueue-", true));
+                PacketQueue.class.getName() + "-", true));
 
     /**
      * Returns true if a warning should be logged after a queue has dropped

--- a/src/main/java/org/ice4j/util/PacketQueue.java
+++ b/src/main/java/org/ice4j/util/PacketQueue.java
@@ -63,7 +63,9 @@ public abstract class PacketQueue<T>
      * when there is no user provided executor.
      */
     private final static ExecutorService sharedExecutor
-        = Executors.newWorkStealingPool();
+        = Executors.newCachedThreadPool(
+            new CustomizableThreadFactory(
+                "PacketQueue-", true));
 
     /**
      * Maximum number of packets processed in row before temporary stop
@@ -535,7 +537,7 @@ public abstract class PacketQueue<T>
          */
         default long maxSequentiallyProcessedPackets()
         {
-            return 50;
+            return -1;
         }
     }
 

--- a/src/main/java/org/ice4j/util/PacketQueue.java
+++ b/src/main/java/org/ice4j/util/PacketQueue.java
@@ -197,7 +197,8 @@ public abstract class PacketQueue<T>
                 queue,
                 new HandlerAdapter(packetHandler),
                 id,
-                executor);
+                executor,
+                packetHandler.maxSequentiallyProcessedPackets());
         }
         else
         {
@@ -479,25 +480,6 @@ public abstract class PacketQueue<T>
         boolean handlePacket(T pkt);
 
         /**
-         * Specifies max number {@link #handlePacket(T)} invocation
-         * per {@link #perNanos()}
-         * @return positive number of allowed packets in case of throttling
-         * must be enabled.
-         */
-        default long maxPackets() {
-            return -1;
-        }
-
-        /**
-         * Specifies time interval in nanoseconds for {@link #maxPackets()}
-         * @return positive nanoseconds count in case of throttling must be
-         * enabled.
-         */
-        default long perNanos() {
-            return -1;
-        }
-
-        /**
          * Specifies the number of packets allowed to be processed sequentially
          * without yielding control to executor's thread. Specifying positive
          * number will allow other possible queues sharing same
@@ -552,33 +534,6 @@ public abstract class PacketQueue<T>
             {
                 releasePacket(item);
             }
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public long maxHandledItems()
-        {
-            return handler.maxPackets();
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public long perNanos()
-        {
-            return handler.perNanos();
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public long maxSequentiallyHandledItems()
-        {
-            return handler.maxSequentiallyProcessedPackets();
         }
     }
 }

--- a/src/main/java/org/ice4j/util/PacketQueue.java
+++ b/src/main/java/org/ice4j/util/PacketQueue.java
@@ -30,6 +30,7 @@ import java.util.logging.Logger; // Disambiguation.
  *     <br> MultiplexingSocket#received (and the rest of Multiplex* classes).
  *
  * @author Boris Grozev
+ * @author Yura Yaroshevich
  */
 public abstract class PacketQueue<T>
 {

--- a/src/main/java/org/ice4j/util/PacketQueue.java
+++ b/src/main/java/org/ice4j/util/PacketQueue.java
@@ -95,13 +95,6 @@ public abstract class PacketQueue<T>
     private final boolean copy;
 
     /**
-     * The capacity of this {@link PacketQueue}. If one of the {@code add}
-     * methods is called while the queue holds this many packets, the first
-     * packet in the queue will be dropped.
-     */
-    private final int capacity;
-
-    /**
      * The {@link QueueStatistics} instance optionally used to collect and print
      * detailed statistics about this queue.
      */
@@ -214,7 +207,6 @@ public abstract class PacketQueue<T>
         ExecutorService executor)
     {
         this.copy = copy;
-        this.capacity = capacity;
         this.id = id;
         queue = new ArrayBlockingQueue<>(capacity);
 
@@ -310,7 +302,7 @@ public abstract class PacketQueue<T>
 
         synchronized (queue)
         {
-            while (queue.size() >= capacity)
+            while (!queue.offer(pkt))
             {
                 // Drop from the head of the queue.
                 T p = queue.poll();
@@ -332,7 +324,6 @@ public abstract class PacketQueue<T>
             {
                 queueStatistics.add(System.currentTimeMillis());
             }
-            queue.offer(pkt);
 
             queue.notifyAll();
 

--- a/src/main/java/org/ice4j/util/PacketQueue.java
+++ b/src/main/java/org/ice4j/util/PacketQueue.java
@@ -191,7 +191,6 @@ public abstract class PacketQueue<T>
         queueStatistics
             = enableStatistics ? new QueueStatistics(id) : null;
 
-
         if (packetHandler != null)
         {
             asyncQueueHandler = new AsyncQueueHandler<T>(

--- a/src/main/java/org/ice4j/util/PacketQueue.java
+++ b/src/main/java/org/ice4j/util/PacketQueue.java
@@ -210,8 +210,11 @@ public abstract class PacketQueue<T>
      * packetHandler for items added to queue. If no explicit executor specified
      * then default {@link #sharedExecutor} will be used.
      */
-    public PacketQueue(int capacity, boolean copy,
-        boolean enableStatistics, String id,
+    public PacketQueue(
+        int capacity,
+        boolean copy,
+        boolean enableStatistics,
+        String id,
         PacketHandler<T> packetHandler,
         ExecutorService executor)
     {

--- a/src/main/java/org/ice4j/util/PacketQueue.java
+++ b/src/main/java/org/ice4j/util/PacketQueue.java
@@ -334,6 +334,8 @@ public abstract class PacketQueue<T>
             }
             queue.offer(pkt);
 
+            queue.notifyAll();
+
             if (reader != null)
             {
                 reader.schedule();
@@ -424,6 +426,11 @@ public abstract class PacketQueue<T>
             if (reader != null)
             {
                 reader.cancel();
+            }
+
+            synchronized (queue)
+            {
+                queue.notifyAll();
             }
         }
     }

--- a/src/main/java/org/ice4j/util/PacketQueue.java
+++ b/src/main/java/org/ice4j/util/PacketQueue.java
@@ -534,7 +534,7 @@ public abstract class PacketQueue<T>
     /**
      * Helper class to calculate throttle delay when throttling must be enabled
      */
-    private final class ThrottleCalculator
+    private static final class ThrottleCalculator<T>
     {
         /**
          * The number of {@link T}s already processed during the current
@@ -549,17 +549,27 @@ public abstract class PacketQueue<T>
         private long intervalStartTimeNanos = 0;
 
         /**
+         * {@link PacketHandler<T>} instance which provide throttling
+         * configuration
+         */
+        private final PacketHandler<T> handler;
+
+        ThrottleCalculator(PacketHandler<T> handler)
+        {
+            if (handler == null)
+            {
+                throw new IllegalArgumentException("handler must not be null");
+            }
+            this.handler = handler;
+        }
+
+        /**
          * Calculate necessary delay based current time and number packets
          * processed processed during current time interval
          * @return 0 in case delay is not necessary or value in nanos
          */
         long getDelayNanos()
         {
-            if (handler == null)
-            {
-                return 0;
-            }
-
             final long perNanos = handler.perNanos();
             final long maxPackets = handler.maxPackets();
 
@@ -604,7 +614,8 @@ public abstract class PacketQueue<T>
          * computing necessary delay before processing next packet when
          * throttling is enabled.
          */
-        private final ThrottleCalculator throttler = new ThrottleCalculator();
+        private final ThrottleCalculator<T> throttler
+            = new ThrottleCalculator<>(handler);
 
         /**
          * Stores <tt>Future</tt> of currently executing {@link #reader}

--- a/src/main/java/org/ice4j/util/PacketQueue.java
+++ b/src/main/java/org/ice4j/util/PacketQueue.java
@@ -419,6 +419,12 @@ public abstract class PacketQueue<T>
         }
     }
 
+    /**
+     * Closes current <tt>PacketQueue</tt> instance. No items will be added
+     * to queue when it's closed. Threads which were blocked in {@link #get()}
+     * will receive <tt>null</tt>. Asynchronous queue processing by
+     * {@link #reader} is stopped.
+     */
     public void close()
     {
         if (closed.compareAndSet(false, true))
@@ -504,7 +510,7 @@ public abstract class PacketQueue<T>
         /**
          * Specifies max number {@link #handlePacket(Object)} invocation
          * per {@link #perNanos()}
-         * @return positive number of allowed pages in case of throttling
+         * @return positive number of allowed packets in case of throttling
          * must be enabled.
          */
         default long maxPackets() {

--- a/src/main/java/org/ice4j/util/PacketQueue.java
+++ b/src/main/java/org/ice4j/util/PacketQueue.java
@@ -16,7 +16,6 @@
 package org.ice4j.util;
 
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.*;
 import java.util.logging.Logger; // Disambiguation.
 
 /**
@@ -98,7 +97,8 @@ public abstract class PacketQueue<T>
     private final String id;
 
     /**
-     * Whether this queue has been closed.
+     * Whether this queue has been closed. Field is denoted as volatile,
+     * because it is set in one thread and could be read in while loop in other.
      */
     private volatile boolean closed = false;
 

--- a/src/test/java/org/ice4j/util/DummyQueue.java
+++ b/src/test/java/org/ice4j/util/DummyQueue.java
@@ -1,6 +1,6 @@
 package org.ice4j.util;
 
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.*;
 
 /**
  * Concrete dummy implementation of PacketQueue. Intended for launching tests

--- a/src/test/java/org/ice4j/util/DummyQueue.java
+++ b/src/test/java/org/ice4j/util/DummyQueue.java
@@ -9,13 +9,21 @@ import java.util.concurrent.ExecutorService;
 class DummyQueue
     extends PacketQueue<DummyQueue.Dummy>
 {
-    DummyQueue(int capacity, boolean copy, boolean enableStatistics,
+    DummyQueue(
+        int capacity,
+        boolean copy,
+        boolean enableStatistics,
         String id,
         PacketHandler<Dummy> packetHandler,
         ExecutorService executor)
     {
         super(capacity, copy, enableStatistics, id, packetHandler,
             executor);
+    }
+
+    DummyQueue(int capacity)
+    {
+        super(capacity, false, false, "DummyQueue", null,     null);
     }
 
     @Override

--- a/src/test/java/org/ice4j/util/DummyQueue.java
+++ b/src/test/java/org/ice4j/util/DummyQueue.java
@@ -11,13 +11,10 @@ class DummyQueue
 {
     DummyQueue(
         int capacity,
-        boolean copy,
-        boolean enableStatistics,
-        String id,
         PacketHandler<Dummy> packetHandler,
         ExecutorService executor)
     {
-        super(capacity, copy, enableStatistics, id, packetHandler,
+        super(capacity, false, false, "DummyQueue", packetHandler,
             executor);
     }
 

--- a/src/test/java/org/ice4j/util/DummyQueue.java
+++ b/src/test/java/org/ice4j/util/DummyQueue.java
@@ -5,6 +5,8 @@ import java.util.concurrent.*;
 /**
  * Concrete dummy implementation of PacketQueue. Intended for launching tests
  * against base implementation of PacketQueue.
+ *
+ * @author Yura Yaroshevich
  */
 class DummyQueue
     extends PacketQueue<DummyQueue.Dummy>

--- a/src/test/java/org/ice4j/util/DummyQueue.java
+++ b/src/test/java/org/ice4j/util/DummyQueue.java
@@ -1,0 +1,55 @@
+package org.ice4j.util;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Concrete dummy implementation of PacketQueue. Intended for launching tests
+ * against base implementation of PacketQueue.
+ */
+class DummyQueue
+    extends PacketQueue<DummyQueue.Dummy>
+{
+    DummyQueue(int capacity, boolean copy, boolean enableStatistics,
+        String id,
+        PacketHandler<Dummy> packetHandler,
+        ExecutorService executor)
+    {
+        super(capacity, copy, enableStatistics, id, packetHandler,
+            executor);
+    }
+
+    @Override
+    public byte[] getBuffer(Dummy pkt)
+    {
+        return null;
+    }
+
+    @Override
+    public int getOffset(Dummy pkt)
+    {
+        return 0;
+    }
+
+    @Override
+    public int getLength(Dummy pkt)
+    {
+        return 0;
+    }
+
+    @Override
+    public Object getContext(Dummy pkt)
+    {
+        return null;
+    }
+
+    @Override
+    protected Dummy createPacket(byte[] buf, int off, int len,
+        Object context)
+    {
+        return new Dummy();
+    }
+
+    static class Dummy {
+        int seed;
+    }
+}

--- a/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java
+++ b/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java
@@ -47,7 +47,7 @@ public class PacketQueueBenchmarkTests
          * This test roughly simulates initial implementation of PacketQueue
          * when each PacketQueue instance has it's own processing thread
          */
-        measureBenchmark("FixedThreadPool", () -> {
+        measureBenchmark("ThreadPerQueuePool", () -> {
             final ExecutorService executorService
                 = Executors.newFixedThreadPool(numberOfQueues);
             Duration duration = runBenchmark(
@@ -68,7 +68,7 @@ public class PacketQueueBenchmarkTests
          * This test is slight modification of previous test, but now threads
          * are re-used between PacketQueues when possible.
          */
-        measureBenchmark("CachedThreadPool", () -> {
+        measureBenchmark("CachedThreadPerQueuePool", () -> {
             final ExecutorService executorService
                 = Executors.newCachedThreadPool();
             Duration duration = runBenchmark(
@@ -86,10 +86,10 @@ public class PacketQueueBenchmarkTests
         throws Exception
     {
         /*
-         * This test is slight modification of previous test, but now threads
-         * are re-used between PacketQueues when possible.
+         * This test creates pool with limited number of threads, all
+         * PacketQueues share threads in cooperative multi-tasking mode.
          */
-        measureBenchmark("FixedSizeThreadPool", () -> {
+        measureBenchmark("FixedSizeCPUBoundPool", () -> {
             final ExecutorService executorService
                 = Executors.newFixedThreadPool(
                     Runtime.getRuntime().availableProcessors());
@@ -117,7 +117,7 @@ public class PacketQueueBenchmarkTests
          * This modification has noticeable better performance when executed
          * on system which is already loaded by other concurrent tasks.
          */
-        measureBenchmark("ForkJoinPool", () -> {
+        measureBenchmark("ForkJoinCPUBoundPool", () -> {
             final ExecutorService executorService
                 = Executors.newWorkStealingPool(
                     Runtime.getRuntime().availableProcessors());

--- a/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java
+++ b/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java
@@ -8,7 +8,7 @@ import java.util.concurrent.*;
 import java.util.logging.Logger;  // Disambiguation
 
 /**
- * Contains test for checking various performance aspects of various
+ * Contains test for checking performance aspects of various
  * PacketQueue configuration
  */
 @Ignore("Check only performance aspect of PacketQueue")

--- a/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java
+++ b/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java
@@ -44,8 +44,8 @@ public class PacketQueueBenchmarkTests
         throws Exception
     {
         /*
-         * This test simulates initial implementation of PacketQueue when
-         * each PacketQueue instance has it's own processing thread
+         * This test roughly simulates initial implementation of PacketQueue
+         * when each PacketQueue instance has it's own processing thread
          */
         measureBenchmark("FixedThreadPool", () -> {
             final ExecutorService executorService
@@ -65,8 +65,8 @@ public class PacketQueueBenchmarkTests
         throws Exception
     {
         /*
-         * This test is slight modification of initial implementation when
-         * threads are reused when possible.
+         * This test is slight modification of previous test, but now threads
+         * are re-used between PacketQueues when possible.
          */
         measureBenchmark("CachedThreadPool", () -> {
             final ExecutorService executorService

--- a/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java
+++ b/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java
@@ -22,6 +22,12 @@ public class PacketQueueBenchmarkTests
         = Logger.getLogger(PacketQueueBenchmarkTests.class.getName());
 
     /**
+     * Number of iteration to run benchmark and compute
+     * average execution time.
+     */
+    private final int numberOfBenchmarkIterations = 100;
+
+    /**
      * Simulates number of concurrent existing PacketQueue instances inside
      * application. In case of JVB it is linear to number of connected peers
      * to JVB instance.
@@ -193,7 +199,7 @@ public class PacketQueueBenchmarkTests
     private void measureBenchmark(String name, Callable<Duration> runWithDuration) throws Exception
     {
         final ArrayList<Duration> experimentDuration = new ArrayList<>();
-        for (int i = 0; i < 21; i++)
+        for (int i = 0; i < 1 + numberOfBenchmarkIterations; i++)
         {
             System.gc();
             final Duration duration = runWithDuration.call();

--- a/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java
+++ b/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java
@@ -10,6 +10,8 @@ import java.util.logging.Logger;  // Disambiguation
 /**
  * Contains test for checking performance aspects of various
  * PacketQueue configuration
+ *
+ * @author Yura Yaroshevich
  */
 @Ignore("Check only performance aspect of PacketQueue")
 public class PacketQueueBenchmarkTests

--- a/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java
+++ b/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java
@@ -1,0 +1,203 @@
+package org.ice4j.util;
+
+import org.junit.*;
+
+import java.time.*;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.logging.Logger;
+
+/**
+ * Contains test for checking various performance aspects of various
+ * PacketQueue configuration
+ */
+@Ignore("Check only performance aspect of PacketQueue")
+public class PacketQueueBenchmarkTests
+{
+    /**
+     * The <tt>Logger</tt> used by the <tt>PacketQueueBenchmarkTests</tt> class
+     * and its instances for logging output.
+     */
+    private static final java.util.logging.Logger logger
+        = Logger.getLogger(PacketQueueBenchmarkTests.class.getName());
+
+    /**
+     * Simulates number of concurrent existing PacketQueue instances inside
+     * application. In case of JVB it is linear to number of connected peers
+     * to JVB instance.
+     */
+    private final int numberOfQueues = 800;
+
+    /**
+     * Simulates number of messages processed via single PacketQueue
+     */
+    private final int numberOfItemsInQueue = 1000;
+
+    /**
+     * Simulates the computation "weight" of single item processed by
+     * PacketQueue
+     */
+    private final int singleQueueItemProcessingWeight = 300;
+
+    @Test
+    public void testMultiplePacketQueueThroughputWithThreadPerQueue()
+        throws Exception
+    {
+        /*
+         * This test simulates initial implementation of PacketQueue when
+         * each PacketQueue instance has it's own processing thread
+         */
+        measureBenchmark("FixedThreadPool", () -> {
+            final ExecutorService executorService
+                = Executors.newFixedThreadPool(numberOfQueues);
+            Duration duration = runBenchmark(
+                executorService,
+                -1 /* Disable cooperative multi-tasking mode,
+                 which is not relevant when each queue has it's own processing
+                 thread*/);
+            executorService.shutdownNow();
+            return duration;
+        });
+    }
+
+    @Test
+    public void testMultiplePacketQueueThroughputWithCachedThreadPerQueue()
+        throws Exception
+    {
+        /*
+         * This test is slight modification of initial implementation when
+         * threads are reused when possible.
+         */
+        measureBenchmark("CachedThreadPool", () -> {
+            final ExecutorService executorService
+                = Executors.newCachedThreadPool();
+            Duration duration = runBenchmark(
+                executorService,
+                -1 /* Disable cooperative multi-tasking mode,
+                 which is not relevant when each queue has it's own processing
+                 thread*/);
+            executorService.shutdownNow();
+            return duration;
+        });
+    }
+
+    @Test
+    public void testMultiplePacketQueueThroughputWithLimitedThreadExecutor()
+        throws Exception
+    {
+        /*
+         * This test check proposed change to PacketQueue implementation when
+         * all created PacketQueues share single ExecutorService with limited
+         * number of threads. Execution starvation is resolved by implementing
+         * cooperative multi-tasking when each PacketQueue release it's thread
+         * borrowed for ExecutorService so other PacketQueue instances can
+         * proceed with execution.
+         * This modification has noticeable better performance when executed
+         * on system which is already loaded by other concurrent tasks.
+         */
+        measureBenchmark("ForkJoinPool", () -> {
+            final ExecutorService executorService
+                = Executors.newWorkStealingPool();
+            Duration duration = runBenchmark(
+                executorService,
+                50 /* Because queues will share executor
+                with limited number of threads, so configure cooperative
+                multi-tasking mode*/);
+            executorService.shutdownNow();
+            return duration;
+        });
+    }
+
+    private Duration runBenchmark(
+        final ExecutorService executor,
+        final long maxSequentiallyPackets)
+        throws InterruptedException
+    {
+        final CountDownLatch completionGuard
+            = new CountDownLatch(numberOfItemsInQueue * numberOfQueues);
+
+        final ArrayList<DummyQueue> queues = new ArrayList<>();
+        for (int i = 0; i < numberOfQueues; i++) {
+            queues.add(new DummyQueue(
+                numberOfItemsInQueue,
+                false,
+                false,
+                String.valueOf(i),
+                new PacketQueue.PacketHandler<DummyQueue.Dummy>()
+                {
+                    @Override
+                    public boolean handlePacket(DummyQueue.Dummy pkt)
+                    {
+                        double result = 0;
+                        // some dummy computationally exp
+                        final int end
+                            = pkt.seed + singleQueueItemProcessingWeight;
+
+                        for (int i = pkt.seed; i < end; i++)
+                        {
+                            result += Math.log(Math.sqrt(i));
+                        }
+                        completionGuard.countDown();
+                        return result > 0;
+                    }
+
+                    @Override
+                    public long maxSequentiallyProcessedPackets()
+                    {
+                        return maxSequentiallyPackets;
+                    }
+                },
+                executor));
+        }
+
+        long startTime = System.nanoTime();
+
+        for (DummyQueue queue : queues)
+        {
+            for (int i = 0; i < numberOfItemsInQueue; i++)
+            {
+                queue.add(new DummyQueue.Dummy());
+            }
+        }
+
+        completionGuard.await();
+        long endTime = System.nanoTime();
+
+        return Duration.ofNanos(endTime - startTime);
+    }
+
+    private void measureBenchmark(String name, Callable<Duration> runWithDuration) throws Exception
+    {
+        final ArrayList<Duration> experimentDuration = new ArrayList<>();
+        for (int i = 0; i < 21; i++) {
+
+            final Duration duration = runWithDuration.call();
+            if (i != 0)
+            {
+                experimentDuration.add(duration);
+            }
+        }
+
+        long totalNanos = 0;
+        for (Duration duration : experimentDuration)
+        {
+            totalNanos += duration.toNanos();
+        }
+        long averageNanos = totalNanos / experimentDuration.size();
+
+        long sumSquares = 0;
+
+        for (Duration duration : experimentDuration)
+        {
+            long diff = Math.abs(duration.toNanos() - averageNanos);
+            sumSquares = diff * diff;
+        }
+
+        double stdDev
+            = Math.sqrt((1.0 / (experimentDuration.size() - 1)) * sumSquares);
+
+        System.out.println(name
+            + " : avg = " + TimeUnit.NANOSECONDS.toMillis(averageNanos) + " ms"
+            + ", std_dev = " + TimeUnit.NANOSECONDS.toMillis((long)stdDev) + " ms");
+    }
+}

--- a/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java
+++ b/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java
@@ -192,8 +192,9 @@ public class PacketQueueBenchmarkTests
     private void measureBenchmark(String name, Callable<Duration> runWithDuration) throws Exception
     {
         final ArrayList<Duration> experimentDuration = new ArrayList<>();
-        for (int i = 0; i < 21; i++) {
-
+        for (int i = 0; i < 21; i++)
+        {
+            System.gc();
             final Duration duration = runWithDuration.call();
             if (i != 0)
             {

--- a/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java
+++ b/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java
@@ -5,7 +5,7 @@ import org.junit.*;
 import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
-import java.util.logging.Logger;
+import java.util.logging.Logger;  // Disambiguation
 
 /**
  * Contains test for checking various performance aspects of various

--- a/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java
+++ b/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java
@@ -143,9 +143,6 @@ public class PacketQueueBenchmarkTests
         for (int i = 0; i < numberOfQueues; i++) {
             queues.add(new DummyQueue(
                 numberOfItemsInQueue,
-                false,
-                false,
-                String.valueOf(i),
                 new PacketQueue.PacketHandler<DummyQueue.Dummy>()
                 {
                     @Override

--- a/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java
+++ b/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java
@@ -183,6 +183,10 @@ public class PacketQueueBenchmarkTests
         completionGuard.await();
         long endTime = System.nanoTime();
 
+        for (DummyQueue queue : queues) {
+            queue.close();
+        }
+
         return Duration.ofNanos(endTime - startTime);
     }
 

--- a/src/test/java/org/ice4j/util/PacketQueueTests.java
+++ b/src/test/java/org/ice4j/util/PacketQueueTests.java
@@ -236,7 +236,7 @@ public class PacketQueueTests
         throws Exception
     {
         final ExecutorService singleThreadExecutor
-            = Executors.newFixedThreadPool(1);
+            = Executors.newSingleThreadExecutor();
 
         final CountDownLatch queueCompletion = new CountDownLatch(1);
 
@@ -253,15 +253,16 @@ public class PacketQueueTests
 
         queue.add(new DummyQueue.Dummy());
 
-        queueCompletion.await();
+        queueCompletion.await(10, TimeUnit.MILLISECONDS);
 
         Future<?> executorCompletion = singleThreadExecutor.submit(() -> {
             // do nothing, just pump Runnable via executor's thread to
             // verify it's not stuck
         });
 
-        try {
-            executorCompletion.get(5, TimeUnit.MILLISECONDS);
+        try
+        {
+            executorCompletion.get(10, TimeUnit.MILLISECONDS);
         }
         catch (TimeoutException e)
         {

--- a/src/test/java/org/ice4j/util/PacketQueueTests.java
+++ b/src/test/java/org/ice4j/util/PacketQueueTests.java
@@ -1,0 +1,161 @@
+package org.ice4j.util;
+
+import junit.framework.TestCase;
+import org.ice4j.stunclient.ResponseSequenceServer;
+import org.junit.Assert;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Test various aspects of {@link PacketQueue} implementation.
+ */
+public class PacketQueueTests
+    extends TestCase
+{
+    /**
+     * The <tt>Logger</tt> used by the <tt>PacketQueueTests</tt> class and
+     * its instances for logging output.
+     */
+    private static final java.util.logging.Logger logger
+        = Logger.getLogger(ResponseSequenceServer.class.getName());
+
+    public void testThrottlingHandlePacket() throws InterruptedException
+    {
+        final long minIntervalBetweenPacketsNanos =
+            TimeUnit.MILLISECONDS.toNanos(10);
+
+        final int itemsCount = 100;
+
+        final CountDownLatch itemsProcessed = new CountDownLatch(itemsCount);
+
+        final AtomicBoolean allItemsWereThrottled = new AtomicBoolean(true);
+
+        final DummyQueue queue = new DummyQueue(
+            itemsCount,
+            false,
+            false,
+            "dummy",
+            new PacketQueue.PacketHandler<Dummy>()
+            {
+
+                private long lastPacketHandledTimestampNanos = -1;
+
+                @Override
+                public boolean handlePacket(Dummy pkt)
+                {
+                    final long now = System.nanoTime();
+
+                    if (lastPacketHandledTimestampNanos != -1)
+                    {
+                        final long durationSinceLastPacketNanos
+                            = now - lastPacketHandledTimestampNanos;
+
+                        final boolean isThrottled
+                            = durationSinceLastPacketNanos
+                                >= minIntervalBetweenPacketsNanos;
+
+                        allItemsWereThrottled.set(
+                            allItemsWereThrottled.get() && isThrottled);
+
+                        if (!isThrottled)
+                        {
+                            logger.log(Level.SEVERE,
+                                "Throttling was not properly applied "
+                            + "between packets processing. Current packet "
+                            + "timestamp is " + now + "us, previous packet "
+                            + "timestamp is " + lastPacketHandledTimestampNanos
+                            + "us, time interval between is "
+                            + durationSinceLastPacketNanos
+                            + "us, expected at least " + perNanos() + "us "
+                            + "between " + maxPackets() + " items");
+                        }
+                    }
+
+                    itemsProcessed.countDown();
+
+                    lastPacketHandledTimestampNanos = now;
+                    return true;
+                }
+
+                @Override
+                public long maxPackets()
+                {
+                    // for easier computation and error message use 1
+                    return 1;
+                }
+
+                @Override
+                public long perNanos()
+                {
+                    // no more than 1 packet per 100 ms
+                    return minIntervalBetweenPacketsNanos;
+                }
+            }, null);
+
+        for (int i = 0; i < itemsCount; i++)
+        {
+            queue.add(new Dummy());
+            Thread.sleep(TimeUnit.NANOSECONDS.toMillis(
+                minIntervalBetweenPacketsNanos / 10));
+        }
+
+        itemsProcessed.await(
+            minIntervalBetweenPacketsNanos * itemsCount,
+            TimeUnit.NANOSECONDS);
+
+        Assert.assertTrue("Expect throttling was done by PacketQueue "
+            + " when maxPackets() and perNanos() specified ",
+            allItemsWereThrottled.get());
+    }
+
+    private class Dummy {
+    }
+
+    private class DummyQueue extends PacketQueue<Dummy>
+    {
+        DummyQueue(int capacity, boolean copy, boolean enableStatistics,
+            String id,
+            PacketHandler<Dummy> packetHandler,
+            ExecutorService executor)
+        {
+            super(capacity, copy, enableStatistics, id, packetHandler,
+                executor);
+        }
+
+        @Override
+        public byte[] getBuffer(Dummy pkt)
+        {
+            return null;
+        }
+
+        @Override
+        public int getOffset(Dummy pkt)
+        {
+            return 0;
+        }
+
+        @Override
+        public int getLength(Dummy pkt)
+        {
+            return 0;
+        }
+
+        @Override
+        public Object getContext(Dummy pkt)
+        {
+            return null;
+        }
+
+        @Override
+        protected Dummy createPacket(byte[] buf, int off, int len,
+            Object context)
+        {
+            return new Dummy();
+        }
+    }
+}

--- a/src/test/java/org/ice4j/util/PacketQueueTests.java
+++ b/src/test/java/org/ice4j/util/PacketQueueTests.java
@@ -1,12 +1,12 @@
 package org.ice4j.util;
 
 import junit.framework.TestCase;
-import org.ice4j.stunclient.ResponseSequenceServer;
 import org.junit.Assert;
+import org.junit.Test;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -15,15 +15,15 @@ import java.util.logging.Logger;
  * Test various aspects of {@link PacketQueue} implementation.
  */
 public class PacketQueueTests
-    extends TestCase
 {
     /**
      * The <tt>Logger</tt> used by the <tt>PacketQueueTests</tt> class and
      * its instances for logging output.
      */
     private static final java.util.logging.Logger logger
-        = Logger.getLogger(ResponseSequenceServer.class.getName());
+        = Logger.getLogger(PacketQueueTests.class.getName());
 
+    @Test
     public void testThrottlingHandlePacket() throws InterruptedException
     {
         final long minIntervalBetweenPacketsNanos =
@@ -40,13 +40,12 @@ public class PacketQueueTests
             false,
             false,
             "dummy",
-            new PacketQueue.PacketHandler<Dummy>()
+            new PacketQueue.PacketHandler<DummyQueue.Dummy>()
             {
-
                 private long lastPacketHandledTimestampNanos = -1;
 
                 @Override
-                public boolean handlePacket(Dummy pkt)
+                public boolean handlePacket(DummyQueue.Dummy pkt)
                 {
                     final long now = System.nanoTime();
 
@@ -99,7 +98,7 @@ public class PacketQueueTests
 
         for (int i = 0; i < itemsCount; i++)
         {
-            queue.add(new Dummy());
+            queue.add(new DummyQueue.Dummy());
             Thread.sleep(TimeUnit.NANOSECONDS.toMillis(
                 minIntervalBetweenPacketsNanos / 10));
         }
@@ -113,49 +112,4 @@ public class PacketQueueTests
             allItemsWereThrottled.get());
     }
 
-    private class Dummy {
-    }
-
-    private class DummyQueue extends PacketQueue<Dummy>
-    {
-        DummyQueue(int capacity, boolean copy, boolean enableStatistics,
-            String id,
-            PacketHandler<Dummy> packetHandler,
-            ExecutorService executor)
-        {
-            super(capacity, copy, enableStatistics, id, packetHandler,
-                executor);
-        }
-
-        @Override
-        public byte[] getBuffer(Dummy pkt)
-        {
-            return null;
-        }
-
-        @Override
-        public int getOffset(Dummy pkt)
-        {
-            return 0;
-        }
-
-        @Override
-        public int getLength(Dummy pkt)
-        {
-            return 0;
-        }
-
-        @Override
-        public Object getContext(Dummy pkt)
-        {
-            return null;
-        }
-
-        @Override
-        protected Dummy createPacket(byte[] buf, int off, int len,
-            Object context)
-        {
-            return new Dummy();
-        }
-    }
 }

--- a/src/test/java/org/ice4j/util/PacketQueueTests.java
+++ b/src/test/java/org/ice4j/util/PacketQueueTests.java
@@ -1,15 +1,12 @@
 package org.ice4j.util;
 
-import junit.framework.TestCase;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.*;
 
-import java.time.Duration;
-import java.util.ArrayList;
+import java.util.*;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.util.concurrent.atomic.*;
+import java.util.logging.*;
+import java.util.logging.Logger; // Disambiguation
 
 /**
  * Test various aspects of {@link PacketQueue} implementation.
@@ -112,4 +109,96 @@ public class PacketQueueTests
             allItemsWereThrottled.get());
     }
 
+    @Test
+    public void testAddingItemToQueueNotifiesBlockedThreadsImmediately()
+        throws Exception
+    {
+        final DummyQueue dummyQueue = new DummyQueue(10);
+        final CompletableFuture<DummyQueue.Dummy> dummyItem =
+            CompletableFuture.supplyAsync(dummyQueue::get);
+
+        try
+        {
+            // This block surrounded with try/catch necessary to ensure that
+            // thread calling PacketQueue::get blocked before items is added
+            // to queue. Giving 50ms for CompletableFuture to stuck on get.
+            final DummyQueue.Dummy nullDummy
+                = dummyItem.get(50, TimeUnit.MILLISECONDS);
+            Assert.fail("There is no items in queue, must not be here");
+        }
+        catch (TimeoutException e)
+        {
+            // no item is added during 50 ms into queue.
+        }
+
+        final DummyQueue.Dummy pushedItem = new DummyQueue.Dummy();
+
+        dummyQueue.add(pushedItem);
+
+        try
+        {
+            // checks that thread stuck in PacketQueue::get notified
+            // "immediately" when item added to queue. Giving 1 ms for
+            // CompletableFuture to transit to completed state.
+            final DummyQueue.Dummy poppedItem = dummyItem.get(
+                1, TimeUnit.MILLISECONDS);
+            Assert.assertEquals(pushedItem, poppedItem);
+        }
+        catch (TimeoutException e)
+        {
+            Assert.fail("Expected that blocked thread notified immediately "
+                + "about item added to queue");
+        }
+    }
+
+    @Test
+    public void testClosingQueueImmediatelyNotifiesAllThreadsBlockedOnGet()
+        throws Exception
+    {
+        final DummyQueue dummyQueue = new DummyQueue(10);
+        final ArrayList<CompletableFuture<DummyQueue.Dummy>>
+            dummyItems = new ArrayList<>();
+        for (int i = 0; i < ForkJoinPool.getCommonPoolParallelism(); i++)
+        {
+            dummyItems.add(CompletableFuture.supplyAsync(dummyQueue::get));
+        }
+
+        for (CompletableFuture<DummyQueue.Dummy> dummyItem : dummyItems)
+        {
+            try
+            {
+                // This block surrounded with try/catch necessary to ensure that
+                // thread calling PacketQueue::get blocked before items is added
+                // to queue. Giving 50ms for CompletableFuture to stuck on get.
+                final DummyQueue.Dummy nullDummy
+                    = dummyItem.get(50, TimeUnit.MILLISECONDS);
+                Assert.fail("There is no items in queue, must not be here");
+            }
+            catch (TimeoutException e)
+            {
+                // no item is added during 50 ms into queue.
+            }
+        }
+
+        dummyQueue.close();
+
+        for (CompletableFuture<DummyQueue.Dummy> dummyItem : dummyItems)
+        {
+            try
+            {
+                // checks that thread stuck in PacketQueue::get notified
+                // "immediately" when PacketQueue is stopped. Giving 1 ms for
+                // CompletableFuture to transit to completed state.
+                final DummyQueue.Dummy poppedItem = dummyItem.get(
+                    1, TimeUnit.MILLISECONDS);
+                Assert.assertNull("When PacketQueue is closed "
+                    + "null must be returned", poppedItem);
+            }
+            catch (TimeoutException e)
+            {
+                Assert.fail("Expected that blocked thread notified immediately "
+                    + "when queue is stopped");
+            }
+        }
+    }
 }

--- a/src/test/java/org/ice4j/util/PacketQueueTests.java
+++ b/src/test/java/org/ice4j/util/PacketQueueTests.java
@@ -11,6 +11,8 @@ import java.util.logging.Logger; // Disambiguation
 
 /**
  * Test various aspects of {@link PacketQueue} implementation.
+ *
+ * @author Yura Yaroshevich
  */
 public class PacketQueueTests
 {

--- a/src/test/java/org/ice4j/util/PacketQueueTests.java
+++ b/src/test/java/org/ice4j/util/PacketQueueTests.java
@@ -51,9 +51,11 @@ public class PacketQueueTests
                         final long durationSinceLastPacketNanos
                             = now - lastPacketHandledTimestampNanos;
 
-                        final boolean isThrottled
-                            = durationSinceLastPacketNanos
-                            >= minIntervalBetweenPacketsNanos;
+                        final long allowedErrorNanos = 1000;
+
+                        final boolean isThrottled = durationSinceLastPacketNanos
+                            >= minIntervalBetweenPacketsNanos
+                                - allowedErrorNanos;
 
                         allItemsWereThrottled.set(
                             allItemsWereThrottled.get() && isThrottled);
@@ -144,10 +146,10 @@ public class PacketQueueTests
         try
         {
             // checks that thread stuck in PacketQueue::get notified
-            // "immediately" when item added to queue. Giving 1 ms for
+            // "immediately" when item added to queue. Giving a few ms for
             // CompletableFuture to transit to completed state.
             final DummyQueue.Dummy poppedItem = dummyItem.get(
-                1, TimeUnit.MILLISECONDS);
+                50, TimeUnit.MILLISECONDS);
             Assert.assertEquals(pushedItem, poppedItem);
         }
         catch (TimeoutException e)
@@ -257,7 +259,7 @@ public class PacketQueueTests
         queue.add(new DummyQueue.Dummy());
 
         final boolean completed
-            = queueCompletion.await(10, TimeUnit.MILLISECONDS);
+            = queueCompletion.await(50, TimeUnit.MILLISECONDS);
         Assert.assertTrue("Expected all queued items are handled "
             + "at this time point", completed);
 

--- a/src/test/java/org/ice4j/util/PacketQueueTests.java
+++ b/src/test/java/org/ice4j/util/PacketQueueTests.java
@@ -201,4 +201,33 @@ public class PacketQueueTests
             }
         }
     }
+
+    @Test
+    public void testAddingWhenCapacityReachedRemovesOldestItem()
+    {
+        final int capacity = 10;
+        final DummyQueue dummyQueue = new DummyQueue(capacity);
+
+        for (int i = 0; i < capacity + 1; i++)
+        {
+            DummyQueue.Dummy item = new DummyQueue.Dummy();
+            item.seed = i;
+
+            dummyQueue.add(item);
+        }
+
+        for (int i = 0; i < capacity + 1; i++)
+        {
+            final DummyQueue.Dummy item = dummyQueue.poll();
+            if (i == capacity)
+            {
+                Assert.assertNull(item);
+            }
+            else
+            {
+                Assert.assertNotEquals("Oldest item must be removed when "
+                    + "item exceeding capacity added", 0, item.seed);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Do not explicitly create threads in `PacketQueue`, but borrow threads for execution from `ExecutorService`.

Currently there is one inheritor from `ice4j`'s `PacketQuque<T>` which is [`RawPacketQueue`](https://github.com/jitsi/libjitsi/blob/6c0a31d6193dcd2b012ae3ced656ad403403d9ff/src/org/jitsi/util/RawPacketQueue.java#L21) in `libjitsi` used by [`SctpConnection`](https://github.com/jitsi/jitsi-videobridge/blob/56d941ae8634a2f2d781f00a7d1a259ee7d1d9d6/src/main/java/org/jitsi/videobridge/SctpConnection.java#L255) in videobridge.

It is observed that currently there is `N` threads created to process queues created by `SctpConnection`. `N` is the total number of peers connected to `JVB`. Most of the time threads are idle and blocked in `wait(100)` inside `while(true)` loop inside empty `PacketQueue`.

This pull request enhances implementation of `PacketQueue` which now temporary borrows execution thread from shared `ExecutorService` and return thread back to pool when there is no work, this results in less threads used and better usage of existing threads managed by `ExecutorService`.

As comment at the header of `PacketQueue` states:
```/**
 * An abstract queue of packets. This is meant to eventually be able to be used
 * in the following classes (in ice4j and libjitsi) in place of their ad-hoc
 * queue implementations (which is the reason the class is parameterized):
 *     <br> RTPConnectorOutputStream.Queue
 *     <br> PushSourceStreamImpl#readQ
 *     <br> OutputDataStreamImpl#writeQ
 *     <br> SinglePortHarvester.MySocket#queue
 *     <br> MultiplexingSocket#received (and the rest of Multiplex* classes).
 *
 * @author Boris Grozev
 */ 
```

This `PacketQueue` implementation could also dramatically reduce thread usage and enhance overall system performance when aforementioned classes migrated from ad-hoc queue implementations to `PacketQueue`.

Current implementation allow switching between different `ExecutorService` implementations: depending on actual handler work, different `ExecutorService` implementation might give different overall performance.

Summary:

* Implementation temporrary borrow execution thread from configurable `ExecutorService` instead of explicit thread creation and waiting when no items in queue to proceed.
* Throttling functionality was added to satisfy requirements of future move of [`RTPConnectorOutputStream.Queue`](https://github.com/jitsi/libjitsi/blob/6c0a31d6193dcd2b012ae3ced656ad403403d9ff/src/org/jitsi/impl/neomedia/RTPConnectorOutputStream.java#L726) to `PacketQueue`
* Due to `ExecutorService` is usually shared between many queues the support of cooperative multi-tasking was added (queue temporary stops it's processing to give execution time to other queues which might work on same `ExecutorService`)
* Unit tests of `PacketQueue` was added
* [Benchmark](https://github.com/jitsi/ice4j/pull/157/files#diff-1519b8e3ad85071f4ff7c1f77cbdde58R14) to compare different `ExecutorService` performance was added. The comparison with baseline implementation added as en example to [different branch in my fork](https://github.com/mstyura/ice4j/commit/37c28b2ae33dbd940d57e581172e3c36f9530585#diff-1519b8e3ad85071f4ff7c1f77cbdde58R134).

Some of micro-benchmark results on my machine (there are too many variations of `numberOfQueues`/`numberOfItemsInQueue`/`singleQueueItemProcessingWeight` to provide all of them):

|change set|PR #157|
|-|-|
|OS |Ubuntu 18.04, 4.13.0-46-generic
|CPU | i7-4790 CPU
|RAM | 16 Gb
|[iterations](https://github.com/jitsi/ice4j/blob/635d8b98d3cb8d5405dce7a434eb8103727a8ccb/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java#L24) | 100
|[numberOfQueues](https://github.com/jitsi/ice4j/blob/e466aa49f1009ed00981924fbbd33c5156704571/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java#L30) | **1200**
|[numberOfItemsInQueue](https://github.com/jitsi/ice4j/blob/e466aa49f1009ed00981924fbbd33c5156704571/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java#L37) | 1000
|[singleQueueItemProcessingWeight](https://github.com/jitsi/ice4j/blob/e466aa49f1009ed00981924fbbd33c5156704571/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java#L42) | 300
|[ThreadPerQueuePool](https://github.com/jitsi/ice4j/blob/635d8b98d3cb8d5405dce7a434eb8103727a8ccb/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java#L56)| avg = 1371 ms, std_dev = 1 ms
|[CachedThreadPerQueuePool](https://github.com/jitsi/ice4j/blob/635d8b98d3cb8d5405dce7a434eb8103727a8ccb/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java#L77)| avg = 1271 ms, std_dev = 0 ms
|[FixedSizeCPUBoundPool](https://github.com/jitsi/ice4j/blob/635d8b98d3cb8d5405dce7a434eb8103727a8ccb/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java#L98)| avg = 1229 ms, std_dev = 0 ms
|[ForkJoinCPUBoundPool](https://github.com/jitsi/ice4j/blob/635d8b98d3cb8d5405dce7a434eb8103727a8ccb/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java#L126)| avg = 1223 ms, std_dev = 0 ms
|[PacketQueueOld](https://github.com/mstyura/ice4j/blob/do-no-block-threads-inside-PacketsQueue-with-PacketQueueOld-benchmark/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java#L138)| avg = 1427 ms, std_dev = 1 ms


|change set|PR #157|
|-|-|
|OS |Ubuntu 18.04, 4.13.0-46-generic
|CPU | i7-4790 CPU
|RAM | 16 Gb
|iterations | 100
|numberOfQueues | **800**
|numberOfItemsInQueue | 1000
|singleQueueItemProcessingWeight | 300
|ThreadPerQueuePool| avg = 925 ms, std_dev = 2 ms
|CachedThreadPerQueuePool| avg = 846 ms, std_dev = 0 ms
|FixedSizeCPUBoundPool| avg = 821 ms, std_dev = 0 ms
|ForkJoinCPUBoundPool| avg = 763 ms, std_dev = 0 ms
|PacketQueueOld| avg = 923 ms, std_dev = 1 ms | # probably faster than `ThreadPerQueuePool` here because all threads created eagerly, instead of lazily by `ExecutorService`.


|change set|PR #157|
|-|-|
|OS |Ubuntu 18.04, 4.13.0-46-generic
|CPU | i7-4790 CPU
|RAM | 16 Gb
|iterations | 100
|numberOfQueues | **400**
|numberOfItemsInQueue | 1000
|singleQueueItemProcessingWeight | 300
|ThreadPerQueuePool| avg = 446 ms, std_dev = 0 ms
|CachedThreadPerQueuePool| avg = 422 ms, std_dev = 0 ms
|FixedSizeCPUBoundPool| avg = 413 ms, std_dev = 0 ms
|ForkJoinCPUBoundPool| avg = 411 ms, std_dev = 0 ms
|PacketQueueOld| avg = 473 ms, std_dev = 1 ms

|change set|PR #157|
|-|-|
|OS |Ubuntu 18.04, 4.13.0-46-generic
|CPU | i7-4790 CPU
|RAM | 16 Gb
|iterations | 100
|numberOfQueues | **200**
|numberOfItemsInQueue | 1000
|singleQueueItemProcessingWeight | 300
|ThreadPerQueuePool| avg = 238 ms, std_dev = 0 ms
|CachedThreadPerQueuePool| avg = 191 ms, std_dev = 0 ms
|FixedSizeCPUBoundPool| avg = 207 ms, std_dev = 0 ms
|ForkJoinCPUBoundPool| avg = 209 ms, std_dev = 0 ms
|PacketQueueOld| avg = 240 ms, std_dev = 1 ms


|change set|PR #157|
|-|-|
|OS |Ubuntu 18.04, 4.13.0-46-generic
|CPU | i7-4790 CPU
|RAM | 16 Gb
|iterations | 100
|numberOfQueues | **100**
|numberOfItemsInQueue | 1000
|singleQueueItemProcessingWeight | 300
|ThreadPerQueuePool| avg = 121 ms, std_dev = 0 ms
|CachedThreadPerQueuePool| avg = 113 ms, std_dev = 0 ms
|FixedSizeCPUBoundPool| avg = 98 ms, std_dev = 0 ms
|ForkJoinCPUBoundPool| avg = 106 ms, std_dev = 0 ms
|PacketQueueOld| avg = 122 ms, std_dev = 0 ms


|change set|PR #157|
|-|-|
|OS |Ubuntu 18.04, 4.13.0-46-generic
|CPU | i7-4790 CPU
|RAM | 16 Gb
|iterations | 100
|numberOfQueues | **5000**
|numberOfItemsInQueue | **400**
|singleQueueItemProcessingWeight | 300
|ThreadPerQueuePool| avg = 2196 ms, std_dev = 17 ms
|CachedThreadPerQueuePool| avg = 2179 ms, std_dev = 2 ms
|FixedSizeCPUBoundPool| avg = 2057 ms, std_dev = 0 ms
|ForkJoinCPUBoundPool| avg = 1900 ms, std_dev = 0 ms
|PacketQueueOld| avg = 2541 ms, std_dev = 12 ms