### PR TITLE
Invoke `releasePacket` on dropped items in `PacketQueue`.

### DIFF
--- a/src/test/java/org/ice4j/util/DummyQueue.java
+++ b/src/test/java/org/ice4j/util/DummyQueue.java
@@ -57,6 +57,6 @@ class DummyQueue
     }
 
     static class Dummy {
-        int seed;
+        int id;
     }
 }

--- a/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java
+++ b/src/test/java/org/ice4j/util/PacketQueueBenchmarkTests.java
@@ -159,9 +159,9 @@ public class PacketQueueBenchmarkTests
                         double result = 0;
                         // some dummy computationally exp
                         final int end
-                            = pkt.seed + singleQueueItemProcessingWeight;
+                            = pkt.id + singleQueueItemProcessingWeight;
 
-                        for (int i = pkt.seed; i < end; i++)
+                        for (int i = pkt.id; i < end; i++)
                         {
                             result += Math.log(Math.sqrt(i));
                         }

--- a/src/test/java/org/ice4j/util/PacketQueueTests.java
+++ b/src/test/java/org/ice4j/util/PacketQueueTests.java
@@ -124,7 +124,7 @@ public class PacketQueueTests
         for (int i = 0; i < capacity + 1; i++)
         {
             DummyQueue.Dummy item = new DummyQueue.Dummy();
-            item.seed = i;
+            item.id = i;
 
             dummyQueue.add(item);
         }
@@ -139,7 +139,7 @@ public class PacketQueueTests
             else
             {
                 Assert.assertNotEquals("Oldest item must be removed when "
-                    + "item exceeding capacity added", 0, item.seed);
+                    + "item exceeding capacity added", 0, item.id);
             }
         }
     }
@@ -310,5 +310,46 @@ public class PacketQueueTests
         {
             queue.close();
         }
+    }
+
+    @Test
+    public void testReleasePacketCalledForPacketsPoppedDueToQueueOverflow()
+        throws Exception {
+
+        final ExecutorService singleThreadedExecutor
+            = Executors.newSingleThreadExecutor();
+
+        final List<DummyQueue.Dummy> releasedPackets = new ArrayList<>();
+
+        final int queueCapacity = 1;
+
+        final DummyQueue queue = new DummyQueue(queueCapacity) {
+            @Override
+            protected void releasePacket(Dummy pkt)
+            {
+                releasedPackets.add(pkt);
+            }
+        };
+
+        final int itemsToEnqueue = 10;
+
+        for (int i = 0; i < itemsToEnqueue; i++)
+        {
+            final DummyQueue.Dummy dummy = new DummyQueue.Dummy();
+            dummy.id = i + 1;
+            queue.add(dummy);
+        }
+
+        Assert.assertEquals(
+            itemsToEnqueue - queueCapacity, releasedPackets.size());
+
+        int seed = 1;
+        for (DummyQueue.Dummy releasedPacket : releasedPackets)
+        {
+            Assert.assertEquals(seed, releasedPacket.id);
+            seed++;
+        }
+
+        singleThreadedExecutor.shutdown();
     }
 }


### PR DESCRIPTION
There was missing call to `releasePacket` when packet was dropped from queue due to queue overflow.

To facilitate usage of object pool in conjunction with `PacketQueue` the missing call to `releasePacket` were added.

A scope of `synchronized` block inside `doAdd` were reduced to just notify objects waiting on `queue`.  The underlying queue is thread-safe and does not need a protection with `syncronized` block. It is also allowed to avoid calling `releasePacket` within `synchronized` block.

A unit test releasing missing call to `releasePacket` were added.