### PR TITLE
Use notify instead of notifyAll when appropariate on hotpaths

### DIFF
--- a/src/main/java/org/ice4j/ice/harvest/AbstractUdpListener.java
+++ b/src/main/java/org/ice4j/ice/harvest/AbstractUdpListener.java
@@ -491,7 +491,7 @@ public abstract class AbstractUdpListener
                     queueStatistics.add(System.currentTimeMillis());
                 }
 
-                queue.notifyAll();
+                queue.notify();
             }
         }
 

--- a/src/main/java/org/ice4j/socket/MergingDatagramSocket.java
+++ b/src/main/java/org/ice4j/socket/MergingDatagramSocket.java
@@ -797,7 +797,7 @@ public class MergingDatagramSocket
                     queue.put(buffer);
                     synchronized (receiveLock)
                     {
-                        receiveLock.notifyAll();
+                        receiveLock.notify();
                     }
                 }
                 catch (InterruptedException ie)


### PR DESCRIPTION
Use `Object.notify` instead of `Object.notifyAll` when only one thread is affected by notification.
`notify` has a slightly better performance according to profiling done with `Visual VM`.