### PR TITLE
Use ReadWriteLock to split receive and close execution in SafeCloseDatagramSocket.

### DIFF
--- a/src/main/java/org/ice4j/socket/SafeCloseDatagramSocket.java
+++ b/src/main/java/org/ice4j/socket/SafeCloseDatagramSocket.java
@@ -141,15 +141,8 @@ public class SafeCloseDatagramSocket
 
         final Lock closeLock = receiveCloseLock.writeLock();
         closeLock.lock();
-        try
-        {
-            // nothing to do, all threads blocked in receive method are
-            // released at this point
-        }
-        finally
-        {
-            closeLock.unlock();
-        }
+        // we now know all read threads have finished
+        closeLock.unlock();
     }
 
     /**


### PR DESCRIPTION
Use `ReadWriteLock` instead of several `synchronized` blocks to split execution of multiple `receive` and `close` inside `SafeCloseDatagramSocket`.
`receive` is method execution on "hot path" in `ice4j` so reducing number of acquired locks is good for performance.