### PR TITLE
Offload I/O from ScheduledExecutorService thread in StunKeepAliveRunner

### DIFF
--- a/src/main/java/org/ice4j/ice/Agent.java
+++ b/src/main/java/org/ice4j/ice/Agent.java
@@ -22,6 +22,7 @@ import java.io.*;
 import java.math.*;
 import java.net.*;
 import java.security.*;
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.logging.*;
@@ -2718,13 +2719,13 @@ public class Agent
         }
 
         @Override
-        protected long getMillisecondsDelayUntilNextRun()
+        protected Duration getDelayUntilNextRun()
         {
             if (shouldRunStunKeepAlive())
             {
-                return keepAliveSent == 0 ? 0 : consentFreshnessInterval;
+                return Duration.ofMillis(keepAliveSent == 0 ? 0 : consentFreshnessInterval);
             }
-            return -1;
+            return Duration.ofMillis(-1);
         }
 
         @Override

--- a/src/main/java/org/ice4j/ice/Agent.java
+++ b/src/main/java/org/ice4j/ice/Agent.java
@@ -121,7 +121,14 @@ public class Agent
      */
     private static final ScheduledExecutorService agentTasksScheduler
         = ExecutorFactory.createCPUBoundScheduledExecutor(
-            "ice4j.Agent-", 60, TimeUnit.SECONDS);
+            "ice4j.Agent-timer-", 60, TimeUnit.SECONDS);
+
+    /**
+     *  The ExecutorService to execute Agent's tasks
+     */
+    private static final ExecutorService agentTasksExecutor
+        = Executors.newCachedThreadPool(
+            new CustomizableThreadFactory("ice4j.Agent-executor-", true));
 
     /**
      * Termination task which will be scheduled with timeout
@@ -2685,7 +2692,7 @@ public class Agent
     /**
      * A class to schedule and perform Stun keep-alive checks
      */
-    private final class StunKeepAliveRunner
+    private final class StunKeepAliveRunner extends PeriodicRunnable
     {
         private final long consentFreshnessInterval = Long.getLong(
             StackProperties.CONSENT_FRESHNESS_INTERVAL,
@@ -2703,97 +2710,62 @@ public class Agent
             StackProperties.CONSENT_FRESHNESS_MAX_RETRANSMISSIONS,
             DEFAULT_CONSENT_FRESHNESS_MAX_RETRANSMISSIONS);
 
-        /**
-         * The scheduled task which sends periodic STUN keep-alive checks.
-         */
-        private ScheduledFuture<?> stunKeepAliveFuture;
+        private int keepAliveSent = 0;
 
-        /**
-         * The object used to synchronize access to {@link #stunKeepAliveFuture}.
-         */
-        private final Object stunKeepAliveFutureSyncRoot = new Object();
-
-        /**
-         * Execute STUN keep-alive checks
-         */
-        private final Runnable runnableCheck = new Runnable()
+        StunKeepAliveRunner()
         {
-            @Override
-            public void run()
-            {
-                for (IceMediaStream stream : getStreams())
-                {
-                    for (Component component : stream.getComponents())
-                    {
-                        for (CandidatePair pair : component.getKeepAlivePairs())
-                        {
-                            if (pair != null)
-                            {
-                                if (performConsentFreshness)
-                                {
-                                    connCheckClient.startCheckForPair(
-                                        pair,
-                                        originalConsentFreshnessWaitInterval,
-                                        maxConsentFreshnessWaitInterval,
-                                        consentFreshnessMaxRetransmissions);
-                                }
-                                else
-                                {
-                                    connCheckClient
-                                        .sendBindingIndicationForPair(pair);
-                                }
-                            }
-                        }
-                    }
-                }
+            super(agentTasksScheduler, agentTasksExecutor);
+        }
 
-                if (!shouldRunStunKeepAlive())
-                {
-                    cancel();
-                }
+        @Override
+        protected long getMillisecondsDelayUntilNextRun()
+        {
+            if (shouldRunStunKeepAlive())
+            {
+                return keepAliveSent == 0 ? 0 : consentFreshnessInterval;
             }
-        };
+            return -1;
+        }
 
-        /**
-         * Schedules execution of periodic task which performs
-         * STUN keep-alive checks
-         */
-        void schedule()
+        @Override
+        protected void run()
         {
-            if (stunKeepAliveFuture == null)
+            try
             {
-                synchronized (stunKeepAliveFutureSyncRoot)
-                {
-                    if (stunKeepAliveFuture == null)
-                    {
-                        logger.info("Starting periodic Stun Keep Alive.");
-
-                        stunKeepAliveFuture
-                            = agentTasksScheduler.scheduleWithFixedDelay(
-                            runnableCheck,
-                            0,
-                            consentFreshnessInterval,
-                            TimeUnit.MILLISECONDS);
-                    }
-                }
+                sendKeepAlive();
+            }
+            catch (Exception e)
+            {
+                logger.log(Level.WARNING, "Error while sending keep alive", e);
             }
         }
 
-        /**
-         * Cancel scheduled periodic task which performs
-         * STUN keep-alive checks
-         */
-        void cancel()
+        private void sendKeepAlive()
         {
-            if (stunKeepAliveFuture != null)
+            ++keepAliveSent;
+
+            for (IceMediaStream stream : getStreams())
             {
-                synchronized (stunKeepAliveFutureSyncRoot)
+                for (Component component : stream.getComponents())
                 {
-                    if (stunKeepAliveFuture != null)
+                    for (CandidatePair pair : component.getKeepAlivePairs())
                     {
-                        stunKeepAliveFuture.cancel(false);
-                        stunKeepAliveFuture = null;
-                        logger.info("Stop periodic Stun Keep Alive.");
+                        if (pair != null)
+                        {
+                            if (performConsentFreshness)
+                            {
+                                connCheckClient.startCheckForPair(
+                                    pair,
+                                    originalConsentFreshnessWaitInterval,
+                                    maxConsentFreshnessWaitInterval,
+                                    consentFreshnessMaxRetransmissions);
+                            }
+                            else
+                            {
+                                connCheckClient
+                                    .sendBindingIndicationForPair(pair);
+                            }
+                        }
                     }
                 }
             }

--- a/src/main/java/org/ice4j/util/PeriodicRunnable.java
+++ b/src/main/java/org/ice4j/util/PeriodicRunnable.java
@@ -91,13 +91,16 @@ public abstract class PeriodicRunnable
             return;
         }
 
+        final long delayMillis =
+            getMillisecondsDelayUntilNextRun();
+
         synchronized (syncRoot)
         {
             if (running)
             {
                 return;
             }
-            scheduleNextRun();
+            scheduleNextRun(delayMillis);
         }
     }
 
@@ -134,15 +137,15 @@ public abstract class PeriodicRunnable
     }
 
     /**
-     * Perform either cancellation or actual scheduling based on current
-     * delay until next run.
+     * Perform either cancellation or actual scheduling based on delay until
+     * next run.
+     * @param delayMillis delay in milliseconds before next
+     *                    execution of {@link #run()}.
      */
-    private void scheduleNextRun()
+    private void scheduleNextRun(long delayMillis)
     {
-        final long delayMillis =
-            getMillisecondsDelayUntilNextRun();
-
-        if (delayMillis < 0) {
+        if (delayMillis < 0)
+        {
             running = false;
             return;
         }
@@ -194,11 +197,14 @@ public abstract class PeriodicRunnable
         {
             if (running)
             {
+                final long delayMillis =
+                    getMillisecondsDelayUntilNextRun();
+
                 synchronized (syncRoot)
                 {
                     if (running)
                     {
-                        scheduleNextRun();
+                        scheduleNextRun(delayMillis);
                     }
                 }
             }

--- a/src/main/java/org/ice4j/util/PeriodicRunnable.java
+++ b/src/main/java/org/ice4j/util/PeriodicRunnable.java
@@ -1,0 +1,242 @@
+package org.ice4j.util;
+
+import java.util.concurrent.*;
+
+/**
+ * A base class for runnables which should be periodically executed on
+ * specified executor service.
+ *
+ * @author Yura Yaroshevich
+ */
+public abstract class PeriodicRunnable
+{
+    /**
+     * A timer to perform periodic scheduling of {@link #run()} execution
+     * on {@link #executor}'s thread.
+     */
+    private final ScheduledExecutorService timer;
+
+    /**
+     * An executor service to perform actual execution of {@link #run()}.
+     */
+    private final ExecutorService executor;
+
+    /**
+     * A synchronization object to synchronize scheduling, execution and
+     * cancellation of {@link #run()}.
+     */
+    private final Object syncRoot = new Object();
+
+    /**
+     * Indicates if execution of {@link #run()} scheduled and should
+     * be further continued.
+     */
+    private volatile boolean running = false;
+
+    /**
+     * Store a reference to last runnable submitted to {@link #timer}
+     */
+    private ScheduledFuture<?> scheduledSubmit;
+
+    /**
+     * Store a reference to last runnable submitted to {@link #executor}
+     */
+    private Future<?> submittedExecute;
+
+    /**
+     * Create instance of {@link PeriodicRunnable} with specified timer and
+     * executor.
+     * @param timer an {@link ScheduledExecutorService} which is used to
+     *              periodic triggering of {@link #run()} execution.
+     * @param executor an {@link ExecutorService} to perform actual execution
+     *                 of {@link #run()}.
+     */
+    protected PeriodicRunnable(
+        ScheduledExecutorService timer,
+        ExecutorService executor)
+    {
+        if (timer == null)
+        {
+            throw new IllegalArgumentException("timer is null");
+        }
+        if (executor == null)
+        {
+            throw new IllegalArgumentException("executor is null");
+        }
+        this.timer = timer;
+        this.executor = executor;
+    }
+
+    /**
+     * Get delay before next execution of {@link #run()}.
+     * @return non-negative value if execution of {@link #run()} should be
+     * performed with specified delay, negative value if execution should not
+     * be done.
+     */
+    protected abstract long getMillisecondsDelayUntilNextRun();
+
+    /**
+     * Periodically executed method on {@link #executor}'s thread.
+     */
+    protected abstract void run();
+
+    /**
+     * Schedules periodic execution of {@link #run()} on {@link #executor}'s
+     * thread.
+     */
+    public void schedule()
+    {
+        if (running)
+        {
+            return;
+        }
+
+        synchronized (syncRoot)
+        {
+            if (running)
+            {
+                return;
+            }
+            scheduleNextRun();
+        }
+    }
+
+    /**
+     * Cancels periodic execution of {@link #run()} on {@link #executor}'s
+     * thread.
+     */
+    public void cancel()
+    {
+        if (!running)
+        {
+            return;
+        }
+
+        synchronized (syncRoot)
+        {
+            if (running)
+            {
+                running = false;
+
+                if (scheduledSubmit != null)
+                {
+                    scheduledSubmit.cancel(true);
+                    scheduledSubmit = null;
+                }
+
+                if (submittedExecute != null)
+                {
+                    submittedExecute.cancel(true);
+                    submittedExecute = null;
+                }
+            }
+        }
+    }
+
+    /**
+     * Perform either cancellation or actual scheduling based on current
+     * delay until next run.
+     */
+    private void scheduleNextRun()
+    {
+        final long delayMillis =
+            getMillisecondsDelayUntilNextRun();
+
+        if (delayMillis < 0) {
+            running = false;
+            return;
+        }
+
+        running = true;
+
+        if (delayMillis == 0)
+        {
+            submitExecuteRun();
+        }
+        else
+        {
+            scheduledSubmit = timer.schedule(
+                this::submitExecuteRun,
+                delayMillis,
+                TimeUnit.MILLISECONDS);
+        }
+    }
+
+    /**
+     * Submit execution of {@link #run()} into {@link #executor}'s thread
+     * if not cancelled.
+     */
+    private void submitExecuteRun()
+    {
+        if (!running)
+        {
+            return;
+        }
+        submittedExecute = this.executor.submit(this::executeRun);
+    }
+
+    /**
+     * Perform execution of {@link #run()} with further re-schedule of
+     * execution if not cancelled
+     */
+    private void executeRun()
+    {
+        if (!running)
+        {
+            return;
+        }
+
+        try
+        {
+            this.run();
+        }
+        finally
+        {
+            if (running)
+            {
+                synchronized (syncRoot)
+                {
+                    if (running)
+                    {
+                        scheduleNextRun();
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Constructs {@link PeriodicRunnable} for {@link Runnable} with provided
+     * timer, executor and fixed delay.
+     * fixed delay.
+     * @param timer {@link ScheduledExecutorService} to be used as timer
+     * @param executor {@link ExecutorService} to execute provided runnable
+     * @param delay delay between subsequent execution of runnable
+     * @param unit time units of delay
+     * @param r {@link Runnable} to for periodic execution.
+     * @return {@link PeriodicRunnable} instance constructed with provided
+     * arguments
+     */
+    static PeriodicRunnable create(
+        ScheduledExecutorService timer,
+        ExecutorService executor,
+        long delay,
+        TimeUnit unit,
+        Runnable r)
+    {
+        return new PeriodicRunnable(timer, executor)
+        {
+            @Override
+            protected long getMillisecondsDelayUntilNextRun()
+            {
+                return unit.toMillis(delay);
+            }
+
+            @Override
+            protected void run()
+            {
+                r.run();
+            }
+        };
+    }
+}

--- a/src/test/java/org/ice4j/util/PeriodicRunnableTests.java
+++ b/src/test/java/org/ice4j/util/PeriodicRunnableTests.java
@@ -2,6 +2,7 @@ package org.ice4j.util;
 
 import org.junit.*;
 
+import java.time.*;
 import java.util.concurrent.*;
 
 /**
@@ -22,8 +23,7 @@ public class PeriodicRunnableTests
         final PeriodicRunnable scheduledRunnable = PeriodicRunnable.create(
             timer,
             executor,
-            100,
-            TimeUnit.MILLISECONDS,
+            Duration.ofMillis(100),
             latch::countDown);
 
         scheduledRunnable.schedule();
@@ -49,8 +49,7 @@ public class PeriodicRunnableTests
         final PeriodicRunnable scheduledRunnable = PeriodicRunnable.create(
             timer,
             executor,
-            -1,
-            TimeUnit.MILLISECONDS,
+            Duration.ofMillis(-1),
             latch::countDown);
 
         scheduledRunnable.schedule();
@@ -75,9 +74,9 @@ public class PeriodicRunnableTests
             new PeriodicRunnable(timer, executor)
             {
                 @Override
-                protected long getMillisecondsDelayUntilNextRun()
+                protected Duration getDelayUntilNextRun()
                 {
-                    return latch.getCount() > 1 ? 100 : -1;
+                    return Duration.ofMillis(latch.getCount() > 1 ? 100 : -1);
                 }
 
                 @Override
@@ -108,8 +107,7 @@ public class PeriodicRunnableTests
         final PeriodicRunnable scheduledRunnable = PeriodicRunnable.create(
             timer,
             executor,
-            500,
-            TimeUnit.MILLISECONDS,
+            Duration.ofMillis(500),
             latch::countDown);
 
         scheduledRunnable.schedule();
@@ -140,8 +138,7 @@ public class PeriodicRunnableTests
         final PeriodicRunnable scheduledRunnable = PeriodicRunnable.create(
             timer,
             executor,
-            200,
-            TimeUnit.MILLISECONDS,
+            Duration.ofMillis(200),
             latch::countDown);
 
         scheduledRunnable.schedule();

--- a/src/test/java/org/ice4j/util/PeriodicRunnableTests.java
+++ b/src/test/java/org/ice4j/util/PeriodicRunnableTests.java
@@ -1,0 +1,163 @@
+package org.ice4j.util;
+
+import org.junit.*;
+
+import java.util.concurrent.*;
+
+public class PeriodicRunnableTests
+{
+    @Test
+    public void scheduleExecutesSpecifiedRunnableMultipleTimes()
+        throws InterruptedException
+    {
+        final ScheduledExecutorService timer
+            = Executors.newSingleThreadScheduledExecutor();
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final CountDownLatch latch = new CountDownLatch(10);
+        final PeriodicRunnable scheduledRunnable = PeriodicRunnable.create(
+            timer,
+            executor,
+            100,
+            TimeUnit.MILLISECONDS,
+            latch::countDown);
+
+        scheduledRunnable.schedule();
+
+        // Give 20 extra milliseconds to avoid possible failures due to
+        // slight timer inaccuracy
+        latch.await(1020, TimeUnit.MILLISECONDS);
+        Assert.assertEquals(0, latch.getCount());
+
+        scheduledRunnable.cancel();
+        executor.shutdownNow();
+        timer.shutdownNow();
+    }
+
+    @Test
+    public void scheduleWithNegativeDelayDoesNotExecuteRunnable()
+        throws InterruptedException
+    {
+        final ScheduledExecutorService timer
+            = Executors.newSingleThreadScheduledExecutor();
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final CountDownLatch latch = new CountDownLatch(1);
+        final PeriodicRunnable scheduledRunnable = PeriodicRunnable.create(
+            timer,
+            executor,
+            -1,
+            TimeUnit.MILLISECONDS,
+            latch::countDown);
+
+        scheduledRunnable.schedule();
+
+        latch.await(1000, TimeUnit.MILLISECONDS);
+        Assert.assertEquals(1, latch.getCount());
+
+        scheduledRunnable.cancel();
+        executor.shutdownNow();
+        timer.shutdownNow();
+    }
+
+    @Test
+    public void negativeDelayStopsFurtherExecution()
+        throws InterruptedException
+    {
+        final ScheduledExecutorService timer
+            = Executors.newSingleThreadScheduledExecutor();
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final CountDownLatch latch = new CountDownLatch(5);
+        final PeriodicRunnable scheduledRunnable =
+            new PeriodicRunnable(timer, executor)
+            {
+                @Override
+                protected long getMillisecondsDelayUntilNextRun()
+                {
+                    return latch.getCount() > 1 ? 100 : -1;
+                }
+
+                @Override
+                protected void run()
+                {
+                    latch.countDown();
+                }
+            };
+
+        scheduledRunnable.schedule();
+
+        latch.await(1000, TimeUnit.MILLISECONDS);
+        Assert.assertEquals(1, latch.getCount());
+
+        scheduledRunnable.cancel();
+        executor.shutdownNow();
+        timer.shutdownNow();
+    }
+
+    @Test
+    public void cancelStopFurtherExecution()
+        throws InterruptedException
+    {
+        final ScheduledExecutorService timer
+            = Executors.newSingleThreadScheduledExecutor();
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final CountDownLatch latch = new CountDownLatch(2);
+        final PeriodicRunnable scheduledRunnable = PeriodicRunnable.create(
+            timer,
+            executor,
+            500,
+            TimeUnit.MILLISECONDS,
+            latch::countDown);
+
+        scheduledRunnable.schedule();
+        latch.await(520, TimeUnit.MILLISECONDS);
+
+        // Check runnable executed once
+        Assert.assertEquals(1, latch.getCount());
+
+        scheduledRunnable.cancel();
+
+        latch.await(1000, TimeUnit.MILLISECONDS);
+        // Check runnable was not executed after cancel.
+        Assert.assertEquals(1, latch.getCount());
+
+        scheduledRunnable.cancel();
+        executor.shutdownNow();
+        timer.shutdownNow();
+    }
+
+    @Test
+    public void scheduleExecuteRunnableIfPreviouslyCancelled()
+        throws InterruptedException
+    {
+        final ScheduledExecutorService timer
+            = Executors.newSingleThreadScheduledExecutor();
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final CountDownLatch latch = new CountDownLatch(5);
+        final PeriodicRunnable scheduledRunnable = PeriodicRunnable.create(
+            timer,
+            executor,
+            200,
+            TimeUnit.MILLISECONDS,
+            latch::countDown);
+
+        scheduledRunnable.schedule();
+        latch.await(220, TimeUnit.MILLISECONDS);
+
+        // Check runnable executed once
+        Assert.assertEquals(4, latch.getCount());
+
+        scheduledRunnable.cancel();
+
+        latch.await(1000, TimeUnit.MILLISECONDS);
+        // Check runnable was not executed after cancel.
+        Assert.assertEquals(4, latch.getCount());
+
+        // Schedule again
+        scheduledRunnable.schedule();
+        latch.await(1000, TimeUnit.MILLISECONDS);
+        Assert.assertEquals(0, latch.getCount());
+
+        scheduledRunnable.cancel();
+        executor.shutdownNow();
+        timer.shutdownNow();
+    }
+}

--- a/src/test/java/org/ice4j/util/PeriodicRunnableTests.java
+++ b/src/test/java/org/ice4j/util/PeriodicRunnableTests.java
@@ -4,6 +4,11 @@ import org.junit.*;
 
 import java.util.concurrent.*;
 
+/**
+ * Test various aspects of {@link PeriodicRunnable} implementation.
+ *
+ * @author Yura Yaroshevich
+ */
 public class PeriodicRunnableTests
 {
     @Test


### PR DESCRIPTION
**TL; DR**: 
Fixed thread starvation in [StunKeepAliveRunner](https://github.com/jitsi/ice4j/blob/e3e78dcda3f791598f6dde256fbaba8ffc2399a3/src/main/java/org/ice4j/ice/Agent.java#L2685) due to operation with blocking I/O executed on `ScheduledExecutorService`'s thread.

**Problem**:
It was reported by Jitsi Team, that changes introduced in PR #151, #152, #153, #155 introduced regression on `TCP`, when there is a thread starvation caused by blocking I/O executed on fixed-size thread pool.

**Solution**:
Split scheduling (delayed execution) from actual execution into different pools: use `ScheduledExecutorService` as a "timer" and cached thread pool for actual task execution. So when some of executed tasks blocked on I/O or something else, it should not prevent scheduling from work and should not affect other tasks.