### PR TITLE
Add unit tests for org.ice4j.ice.NetworkUtilsTest

### DIFF
--- a/src/test/java/org/ice4j/ice/NetworkUtilsTest.java
+++ b/src/test/java/org/ice4j/ice/NetworkUtilsTest.java
@@ -24,6 +24,40 @@ import org.junit.*;
 public class NetworkUtilsTest
 {
     @Test
+    public void testIpv4StringToBytes()
+    {
+        byte[] addr = NetworkUtils.strToIPv4("1");
+        assertNotNull(addr);
+        assertEquals(1, addr[3]);
+
+        addr = NetworkUtils.strToIPv4("1.2");
+        assertNotNull(addr);
+        assertEquals(2, addr[3]);
+
+        addr = NetworkUtils.strToIPv4("1.2.3");
+        assertNotNull(addr);
+        assertEquals(3, addr[3]);
+
+        addr = NetworkUtils.strToIPv4("1.2.3.4");
+        assertNotNull(addr);
+        assertEquals(4, addr[3]);
+
+        assertNull(NetworkUtils.strToIPv4(""));
+        assertNull(NetworkUtils.strToIPv4("-1"));
+        assertNull(NetworkUtils.strToIPv4("1.-2"));
+        assertNull(NetworkUtils.strToIPv4("-1.2"));
+        assertNull(NetworkUtils.strToIPv4("1.-2.3"));
+        assertNull(NetworkUtils.strToIPv4("1.2.-3"));
+        assertNull(NetworkUtils.strToIPv4("-1.2.3"));
+        assertNull(NetworkUtils.strToIPv4("1.-2.3.4"));
+        assertNull(NetworkUtils.strToIPv4("1.2.-3.4"));
+        assertNull(NetworkUtils.strToIPv4("1.2.3.-4"));
+        assertNull(NetworkUtils.strToIPv4("-1.2.3.4"));
+        assertNull(NetworkUtils.strToIPv4("1.2.3.4.5"));
+        assertNull(NetworkUtils.strToIPv4("1.2.3.256"));
+    }
+
+    @Test
     public void testIpv6StringToBytes()
     {
         byte[] addr = NetworkUtils.strToIPv6("::12");
@@ -42,6 +76,12 @@ public class NetworkUtilsTest
         assertNotNull(addr);
         assertEquals(18, addr[15]);
 
+        assertNull(NetworkUtils.strToIPv6(""));
+        assertNull(NetworkUtils.strToIPv6(":::"));
+        assertNull(NetworkUtils.strToIPv6("[^"));
+        assertNull(NetworkUtils.strToIPv6("[%"));
+        assertNull(NetworkUtils.strToIPv6(":?0"));
         assertNull(NetworkUtils.strToIPv6("[::12]%1"));
+        assertNull(NetworkUtils.strToIPv6("[::65536]%1"));
     }
 }


### PR DESCRIPTION
Hi, I've analysed your codebase and seen some gaps in the coverage of:

org.ice4j.ice.NetworkUtilsTest

I've written tests with the help of [Diffblue Cover](https://www.diffblue.com/products) and increased line coverage for the following methods:
strToIPv4()
strToIPv6()
Total line coverage for the class, according to IntelliJ, is now 118/220 (53.6%); was 71/220 (32.3%) 
Hopefully, they will help you detect regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important.