### PR TITLE
Update jain-sip version and remove NistSdpFactory dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 .project
 .settings/
 bin/
+
+# Ignore IntelliJ IDEA files
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -21,14 +21,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.opentelecoms.sdp</groupId>
-      <artifactId>java-sdp-nist-bridge</artifactId>
-      <version>1.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jitsi</groupId>
-      <artifactId>jain-sip-ri-ossonly</artifactId>
-      <version>1.2.98c7f8c-jitsi-oss1</version>
+      <groupId>javax.sip</groupId>
+      <artifactId>jain-sip-ri</artifactId>
+      <version>1.3.0-91</version>
     </dependency>
     <dependency>
       <groupId>org.bitlet</groupId>

--- a/src/main/java/org/ice4j/ice/sdp/IceSdpUtils.java
+++ b/src/main/java/org/ice4j/ice/sdp/IceSdpUtils.java
@@ -19,7 +19,6 @@ package org.ice4j.ice.sdp;
 
 import org.ice4j.*;
 import org.ice4j.ice.*;
-import org.opentelecoms.javax.sdp.*;
 
 import javax.sdp.*;
 import java.util.*;
@@ -72,7 +71,7 @@ public class IceSdpUtils
     /**
      * A reference to the currently valid SDP factory instance.
      */
-    private static final SdpFactory sdpFactory = new NistSdpFactory();
+    private static final SdpFactory sdpFactory = SdpFactory.getInstance();
 
     /**
      * The <tt>Logger</tt> used by the <tt>IceSdpUtils</tt>

--- a/src/test/java/test/IcePseudoTcp.java
+++ b/src/test/java/test/IcePseudoTcp.java
@@ -30,7 +30,7 @@ import org.ice4j.security.*;
 
 /**
  * Sample program which first uses ICE to discover UDP connectivity. After that
- * selected cadidates are used by "remote" and "local" pseudoTCP peers to
+ * selected candidates are used by "remote" and "local" pseudoTCP peers to
  * transfer some test data.
  *
  * @author Pawel Domas

--- a/src/test/java/test/SdpUtils.java
+++ b/src/test/java/test/SdpUtils.java
@@ -24,7 +24,6 @@ import javax.sdp.*;
 import org.ice4j.*;
 import org.ice4j.ice.*;
 import org.ice4j.ice.sdp.*;
-import org.opentelecoms.javax.sdp.*;
 
 /**
  * Utilities for manipulating SDP. Some of the utilities in this method <b>do
@@ -54,7 +53,7 @@ public class SdpUtils
      */
     public static String createSDPDescription(Agent agent) throws Throwable
     {
-        SdpFactory factory = new NistSdpFactory();
+        SdpFactory factory = SdpFactory.getInstance();
         SessionDescription sdess = factory.createSessionDescription();
 
         IceSdpUtils.initSessionDescription(sdess, agent);
@@ -76,7 +75,7 @@ public class SdpUtils
     public static void parseSDP(Agent localAgent, String sdp)
         throws Exception
     {
-        SdpFactory factory = new NistSdpFactory();
+        SdpFactory factory = SdpFactory.getInstance();
         SessionDescription sdess = factory.createSessionDescription(sdp);
 
         for(IceMediaStream stream : localAgent.getStreams())


### PR DESCRIPTION
Hi, I am a new user of `ice4j` and this is my first pull request.  There are two changes:

1. Upgrade `jain-sip` to more recent version 1.3.0-91 in Maven repo. It helps when the application is using more recent `jain-sip` version.
2. Remove the dependency of `java-sdp-nist-bridge` from `org.opentelecoms.sdp` because it is no longer needed after moving to the newer version of `jain-sip`.  (Note that `SdpFactory` is a Singleton now instead of an abstract class). 

All existing tests passed. Please review and merge. Thank you! 
