### PR TITLE
Fix Retransmitter creation to take effect of originalWaitInterval config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 .project
 .settings/
 bin/
+
+# Ignore IntelliJ IDEA files
+.idea
+*.iml

--- a/src/main/java/org/ice4j/stack/StunClientTransaction.java
+++ b/src/main/java/org/ice4j/stack/StunClientTransaction.java
@@ -150,7 +150,7 @@ public class StunClientTransaction
     /**
      * A transaction request retransmitter
      */
-    private final Retransmitter retransmitter = new Retransmitter();
+    private final Retransmitter retransmitter;
 
     /**
      * Creates a client transaction.
@@ -205,6 +205,8 @@ public class StunClientTransaction
         this.requestDestination = requestDestination;
 
         initTransactionConfiguration();
+
+        retransmitter = new Retransmitter(); // create it here to support 'originalWaitInterval' configuration
 
         this.transactionID = transactionID;
 

--- a/src/test/java/org/ice4j/stack/DatagramCollector.java
+++ b/src/test/java/org/ice4j/stack/DatagramCollector.java
@@ -36,7 +36,8 @@ public class DatagramCollector
     {
         try
         {
-
+            // The 'receive' method synchronized the packet, hence the 'getData()' (also synchronized) will block
+            // on this anyway even after 'waitForPacket' and 'collectPacket' calls.
             sock.receive(receivedPacket);
 
             synchronized (this)

--- a/src/test/java/org/ice4j/stack/ShallowStackTest.java
+++ b/src/test/java/org/ice4j/stack/ShallowStackTest.java
@@ -371,6 +371,8 @@ public class ShallowStackTest extends TestCase
         // verify the retransmission is longer than the originalWait
         long secondTime = System.currentTimeMillis();
          assertTrue((secondTime - firstTime) >= originalWait);
+
+         System.clearProperty(StackProperties.FIRST_CTRAN_RETRANS_AFTER);
     }
 
     //--------------------------------------- listener implementations ---------


### PR DESCRIPTION
Hi,

I found that `originalWaitInterval` configuration does not really take effect for `Retransmitter` in `StunClientTransaction`.  The reason was that `retransmitter` was initialized at its declaration instead of in the constructor of `StunClientTransaction`. 

Changes:
1. I've made a change to fix that and added a test following existing testing pattern. 
2. Also it seems that the test class `DatagramCollector` implicitly depends on the jave.net.DatagramSocket locking the packet. I've added a comment for that.  (And in theory there is a issue with Thread.start() timing as well in this test class `DatagramCollector`, but it seems ok with existing tests. ) 

Please review, thanks. 

