### PR TITLE
increase major version number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.jitsi</groupId>
   <artifactId>ice4j</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>3.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>ice4j</name>


### PR DESCRIPTION
@bgrozev and i have discussed making some changes in ice4j that may or may not work for jitsi desktop (or, at least, not in the same timeframe we want to use them elsewhere).  after talking with @damencho as well, we decided a plan forward would be to cut ice4j's current master to a branch (which can be found [here](https://github.com/jitsi/ice4j/tree/v2.x)) and changing master over to 3.0.  We can continue to deploy the 2.0 branch to sonatype and Jitsi desktop can use the 2.0 versions. The 3.0 (master branch) will be deployed to the jitsi repo.  

Appropriate changes can be ported from master to the 2.0 branch, but it would not necessarily get every change from 3.0 (the new master).