### PR TITLE
Added `Message-Integrity` attribute to `Role Conflict` message.

### DIFF
--- a/src/main/java/org/ice4j/ice/Agent.java
+++ b/src/main/java/org/ice4j/ice/Agent.java
@@ -242,7 +242,7 @@ public class Agent
     private long tieBreaker;
 
     /**
-     * Determines whether this is the controlling agent in a an ICE interaction.
+     * Determines whether this agent has a controlling role in an ICE interaction.
      */
     private boolean isControlling = true;
 
@@ -402,7 +402,8 @@ public class Agent
             addCandidateHarvester(harvester);
         }
 
-        logger.debug(() -> "Created a new Agent");
+        logger.debug(() -> "Created a new Agent: " + this.toString() +
+            " with ICE controlling role = " + this.isControlling);
     }
 
     /**
@@ -1407,8 +1408,13 @@ public class Agent
      */
     public void setControlling(boolean isControlling)
     {
-        this.logger.info(() -> "Changing agent " + this.toString() + " role from controlling = "
-            + this.isControlling + " to controlling = " + isControlling);
+        if (this.isControlling != isControlling)
+        {
+            this.logger.info(() -> "Changing agent " + this.toString() +
+                " role from controlling = " + this.isControlling +
+                " to controlling = " + isControlling);
+        }
+
         this.isControlling = isControlling;
 
         //in case we have already initialized our check lists we'd need to

--- a/src/main/java/org/ice4j/ice/Agent.java
+++ b/src/main/java/org/ice4j/ice/Agent.java
@@ -1407,6 +1407,8 @@ public class Agent
      */
     public void setControlling(boolean isControlling)
     {
+        this.logger.info(() -> "Changing agent " + this.toString() + " role from controlling = "
+            + this.isControlling + " to controlling = " + isControlling);
         this.isControlling = isControlling;
 
         //in case we have already initialized our check lists we'd need to

--- a/src/main/java/org/ice4j/ice/ConnectivityCheckServer.java
+++ b/src/main/java/org/ice4j/ice/ConnectivityCheckServer.java
@@ -302,7 +302,7 @@ class ConnectivityCheckServer
             }
         }
         //If the agent's tie-breaker is less than the contents of the
-        //ICE control attribute, the agent toggles it's ICE control role.
+        //ICE control attribute, the agent toggles its ICE control role.
         else
         {
             final String selfNextControlState

--- a/src/test/java/org/ice4j/ice/RoleConflictResolutionTest.java
+++ b/src/test/java/org/ice4j/ice/RoleConflictResolutionTest.java
@@ -1,0 +1,196 @@
+/*
+ * ice4j, the OpenSource Java Solution for NAT and Firewall Traversal.
+ *
+ * Copyright @ 2019 8x8, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ice4j.ice;
+
+import org.ice4j.*;
+import org.junit.*;
+
+import java.io.*;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.logging.*;
+
+/**
+ * RoleConflictResolutionTest set of tests which does end-to-end test
+ * of ICE role conflict recovery.
+ *
+ * @author Yura Yaroshevich
+ */
+public class RoleConflictResolutionTest
+{
+    protected static final Logger logger
+        = Logger.getLogger(RoleConflictResolutionTest.class.getName());
+
+    @Test
+    public void testRecoveryFromBothControlledConflict()
+        throws Throwable
+    {
+        testRecoveryFromRoleConflict(false);
+    }
+
+    @Test
+    public void testRecoveryFromBothControllingConflict()
+        throws Throwable
+    {
+        testRecoveryFromRoleConflict(true);
+    }
+
+    private static void testRecoveryFromRoleConflict(boolean bothControlling)
+        throws Throwable
+    {
+        final Agent peer1 = createPeer("[peer-1]", bothControlling);
+        // Set explicit tie-breakers to avoid automatic conflict resolution
+        peer1.setTieBreaker(1);
+
+        final Agent peer2 = createPeer("[peer-2]", bothControlling);
+        peer1.setTieBreaker(2);
+
+        final CountDownLatch countDownLatch = new CountDownLatch(2);
+
+        for (Agent peer : Arrays.asList(peer1, peer2))
+        {
+            peer.addStateChangeListener(evt ->
+            {
+                logger.info(peer.toString() + ": state changed to " + evt.toString());
+                if (peer.getState().isEstablished())
+                {
+                    countDownLatch.countDown();
+                }
+            });
+        }
+
+        exchangeCredentials(peer1, peer2);
+        exchangeCandidates(peer1, peer2);
+
+        peer1.startConnectivityEstablishment();
+        peer2.startConnectivityEstablishment();
+
+        boolean isConnected = countDownLatch.await(20, TimeUnit.SECONDS);
+
+        logSelectedPairs(peer1);
+        logSelectedPairs(peer2);
+
+        Assert.assertTrue("Expected connection established within time out",
+            isConnected);
+        Assert.assertTrue("peer 1 connectivity",
+            peer1.getState().isEstablished());
+        Assert.assertTrue("peer 2 connectivity",
+            peer2.getState().isEstablished());
+
+        disposePeer(peer1);
+        disposePeer(peer2);
+    }
+
+    private static Agent createPeer(String label, boolean iceControlling) throws IOException
+    {
+        final Agent agent = new Agent(label, null);
+        agent.setUseHostHarvester(true);
+        agent.setControlling(iceControlling);
+        IceMediaStream iceStream
+            = agent.createMediaStream("media-stream");
+
+        agent.createComponent(
+            iceStream,
+            Transport.UDP,
+            0x400, 0x400, 0xFFFF,
+            KeepAliveStrategy.ALL_SUCCEEDED,
+            true);
+
+        return agent;
+    }
+
+    private static void disposePeer(Agent peer)
+    {
+        peer.free();
+    }
+
+    private static void logSelectedPairs(Agent peer)
+    {
+        for (IceMediaStream stream : peer.getStreams())
+        {
+            for (Component component : stream.getComponents())
+            {
+                CandidatePair selectedPair = component.getSelectedPair();
+                if (selectedPair != null)
+                {
+                    logger.info( peer.toString() + ": selected pair for " +
+                        "component " + component.getName() + " :" +
+                        selectedPair.toString());
+                }
+            }
+        }
+    }
+
+    private static void exchangeCredentials(Agent peer1, Agent peer2)
+    {
+        for(IceMediaStream stream : peer2.getStreams())
+        {
+            stream.setRemoteUfrag(peer1.getLocalUfrag());
+            stream.setRemotePassword(peer1.getLocalPassword());
+        }
+
+        for(IceMediaStream stream : peer1.getStreams())
+        {
+            stream.setRemoteUfrag(peer2.getLocalUfrag());
+            stream.setRemotePassword(peer2.getLocalPassword());
+        }
+    }
+
+    private static void exchangeCandidates(Agent peer1, Agent peer2)
+    {
+        for (String streamName : peer1.getStreamNames())
+        {
+            IceMediaStream peer1Stream = peer1.getStream(streamName);
+            IceMediaStream peer2Stream = peer2.getStream(streamName);
+            if (peer1Stream == null || peer2Stream == null)
+            {
+                continue;
+            }
+
+            for (Integer id : peer1Stream.getComponentIDs())
+            {
+                Component peer1Component = peer1Stream.getComponent(id);
+                Component peer2Component = peer2Stream.getComponent(id);
+                if (peer1Component == null || peer2Component == null)
+                {
+                    continue;
+                }
+
+                copyRemoteCandidates(peer1Component, peer2Component);
+                copyRemoteCandidates(peer2Component, peer1Component);
+            }
+        }
+    }
+
+    private static void copyRemoteCandidates(Component localComponent,
+                                             Component remoteComponent)
+    {
+        for(LocalCandidate candidate : remoteComponent.getLocalCandidates())
+        {
+            localComponent.addRemoteCandidate(
+                new RemoteCandidate(
+                    candidate.getTransportAddress(),
+                    localComponent,
+                    candidate.getType(),
+                    candidate.getFoundation(),
+                    candidate.getPriority(),
+                    null));
+        }
+    }
+}

--- a/src/test/java/org/ice4j/ice/RoleConflictResolutionTest.java
+++ b/src/test/java/org/ice4j/ice/RoleConflictResolutionTest.java
@@ -67,7 +67,8 @@ public class RoleConflictResolutionTest
         {
             peer.addStateChangeListener(evt ->
             {
-                logger.info(peer.toString() + ": state changed to " + evt.toString());
+                logger.info(peer.toString() + ": state changed to "
+                    + evt.toString());
                 if (peer.getState().isEstablished())
                 {
                     countDownLatch.countDown();
@@ -97,7 +98,8 @@ public class RoleConflictResolutionTest
         disposePeer(peer2);
     }
 
-    private static Agent createPeer(String label, boolean iceControlling) throws IOException
+    private static Agent createPeer(String label, boolean iceControlling)
+        throws IOException
     {
         final Agent agent = new Agent(label, null);
         agent.setUseHostHarvester(true);


### PR DESCRIPTION
When `ICE` role conflict happens, `ice4j` sends `Role Conflict` message, which is not liked by both `Chrome` and `Firefox`.
Firefox seems to drops such `STUN` error response, producing following logs:
```
(ice/INFO) ICE-PEER(PC:1568974392290000 (id=40802189545 url=https://127.0.0.1:9980/):default)/CAND-PAIR(pX/O): setting pair to state IN_PROGRESS: pX/O|IP4:10.0.75.1:60420/UDP|IP4:10.0.75.1:10000/UDP(host(IP4:10.0.75.1:60420/UDP)|candidate:1 1 udp 2130706431 10.0.75.1 10000 typ host generation 0)

(stun/INFO) STUN-CLIENT(pX/O|IP4:10.0.75.1:60420/UDP|IP4:10.0.75.1:10000/UDP(host(IP4:10.0.75.1:60420/UDP)|candidate:1 1 udp 2130706431 10.0.75.1 10000 typ host generation 0)): Received response; processing

(stun/WARNING) Missing MESSAGE-INTEGRITY

(stun/WARNING) STUN-CLIENT(pX/O|IP4:10.0.75.1:60420/UDP|IP4:10.0.75.1:10000/UDP(host(IP4:10.0.75.1:60420/UDP)|candidate:1 1 udp 2130706431 10.0.75.1 10000 typ host generation 0)): Error processing response: Operation rejected, stun error code 0.
```

`Chrome` seems to do the same, but [silenty](https://cs.chromium.org/chromium/src/third_party/webrtc/p2p/base/connection.cc?rcl=fb59a6aa3f718241506fb644f4daa295f992d596&l=457).

According to `Chrome` [source code](https://cs.chromium.org/chromium/src/third_party/webrtc/p2p/base/port.cc?rcl=fb59a6aa3f718241506fb644f4daa295f992d596&l=749) `Message-Integrity` is mandatory attribute for `Role Conflict` message.

With this fix, `Chrome` properly handles `Role Conflict` response and switched it's role.
`Firefox` for some reason still unable to handle `STUN` error response to recover from `Role Conflict`, but have different message in logs:
```
(ice/INFO) ICE-PEER(PC:1568984401039000 (id=40802189569 url=https://127.0.0.1:9980/):default)/CAND-PAIR(8hTQ): setting pair to state IN_PROGRESS: 8hTQ|IP4:10.0.75.1:52398/UDP|IP4:10.0.75.1:10000/UDP(host(IP4:10.0.75.1:52398/UDP)|candidate:1 1 udp 2130706431 10.0.75.1 10000 typ host generation 0)

(stun/INFO) STUN-CLIENT(8hTQ|IP4:10.0.75.1:52398/UDP|IP4:10.0.75.1:10000/UDP(host(IP4:10.0.75.1:52398/UDP)|candidate:1 1 udp 2130706431 10.0.75.1 10000 typ host generation 0)): Received response; processing

(stun/WARNING) STUN-CLIENT(8hTQ|IP4:10.0.75.1:52398/UDP|IP4:10.0.75.1:10000/UDP(host(IP4:10.0.75.1:52398/UDP)|candidate:1 1 udp 2130706431 10.0.75.1 10000 typ host generation 0)): Error processing response: Retry may be possible, stun error code 487.

(ice/INFO) ICE-PEER(PC:1568984401039000 (id=40802189569 url=https://127.0.0.1:9980/):default)/CAND-PAIR(zpTK): setting pair to state IN_PROGRESS: zpTK|IP4:10.0.75.1:52398/UDP|IP4:172.19.103.121:10000/UDP(host(IP4:10.0.75.1:52398/UDP)|candidate:2 1 udp 2130706431 172.19.103.121 10000 typ host generation 0)
```

I've inspected `Firefox` source code responsible for `ICE` implementation and was failed to find proper role conflict implementation... There are code bits which handles role conflict, but for some reason they were not executed according to logs :(
