### PR TITLE
Updated java-sdp-nist-bridge and removed explict jain-sip-ri-ossonly dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,11 +26,6 @@
       <version>1.1</version>
     </dependency>
     <dependency>
-      <groupId>org.jitsi</groupId>
-      <artifactId>jain-sip-ri-ossonly</artifactId>
-      <version>1.2.98c7f8c-jitsi-oss1</version>
-    </dependency>
-    <dependency>
       <groupId>org.bitlet</groupId>
       <artifactId>weupnp</artifactId>
       <version>0.1.4</version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>org.opentelecoms.sdp</groupId>
       <artifactId>java-sdp-nist-bridge</artifactId>
-      <version>1.1</version>
+      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>org.bitlet</groupId>


### PR DESCRIPTION
It seems that removed dependency is unused. 
```
 mvn clean package test
```
completes without errors with that dependency removed.