### PR TITLE
Merge duplicate ICE candidate pairs.

### DIFF
--- a/src/main/java/org/ice4j/ice/CheckList.java
+++ b/src/main/java/org/ice4j/ice/CheckList.java
@@ -210,6 +210,25 @@ public class CheckList
     }
 
     /**
+     * Returns a pair which matches the specified local and remote candidates'
+     * transport addresses, if any, otherwise null.
+     */
+    public synchronized CandidatePair findPairMatching(LocalCandidate local, RemoteCandidate remote)
+    {
+        for (CandidatePair pair : this)
+        {
+            if (pair.getLocalCandidate() == local ||
+                pair.getLocalCandidate().getTransportAddress().equals(local.getTransportAddress()))
+            {
+                if (pair.getRemoteCandidate() == remote ||
+                    pair.getRemoteCandidate().getTransportAddress().equals(remote.getTransportAddress()))
+                    return pair;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Determines whether this <tt>CheckList</tt> can be considered active.
      * RFC 5245 says: A check list with at least one pair that is Waiting is
      * called an active check list.

--- a/src/main/java/org/ice4j/ice/Component.java
+++ b/src/main/java/org/ice4j/ice/Component.java
@@ -437,8 +437,6 @@ public class Component
                             = getParentStream()
                                 .getParentAgent()
                                     .createCandidatePair(localCnd, remoteCnd);
-                        logger.info("new Pair added: " + pair.toShortString()
-                            + ".");
                         checkList.add(pair);
                     }
                 }
@@ -465,7 +463,24 @@ public class Component
             {
                 for (CandidatePair pair : checkList)
                 {
-                    streamCheckList.add(pair);
+                    /* Check whether the pair is already in the check list.
+                     * (This can happen for pairs with remote peer-reflexive candidates,
+                     *  since those candidates aren't added to the candidate list even
+                     *  though the pair is added to the check list).
+                     */
+                    CandidatePair existingPair = streamCheckList.findPairMatching(pair.getLocalCandidate(), pair.getRemoteCandidate());
+                    if (existingPair != null) {
+                        logger.info("existing Pair updated: " +
+                            existingPair.toShortString() +
+                            " to " + pair.toShortString() + ".");
+                        existingPair.setRemoteCandidate(pair.getRemoteCandidate());
+                        existingPair.computePriority();
+                    }
+                    else {
+                        streamCheckList.add(pair);
+                        logger.info("new Pair added: " + pair.toShortString()
+                            + ".");
+                    }
                 }
             }
         }


### PR DESCRIPTION
This can happen if a remote candidate is discovered as peer-reflexive and later received over signaling.