### PR TITLE
Avoid double-nomination of ICE candidate pairs.

### DIFF
--- a/src/main/java/org/ice4j/ice/DefaultNominator.java
+++ b/src/main/java/org/ice4j/ice/DefaultNominator.java
@@ -104,9 +104,10 @@ public class DefaultNominator
 
             CandidatePair validPair = (CandidatePair) ev.getSource();
 
-            // do not nominate pair if there is currently a selected pair for
+            // do not nominate pair if there is currently a nominated pair for
             // the component
-            if (validPair.getParentComponent().getSelectedPair() != null)
+            if (validPair.getParentComponent().getParentStream().
+                validListContainsNomineeForComponent(validPair.getParentComponent()))
             {
                 logger.debug(() ->
                         "Keep-alive for pair: " + validPair.toShortString());

--- a/src/main/java/org/ice4j/ice/DefaultNominator.java
+++ b/src/main/java/org/ice4j/ice/DefaultNominator.java
@@ -103,11 +103,12 @@ public class DefaultNominator
                 return;
 
             CandidatePair validPair = (CandidatePair) ev.getSource();
+            Component parentComponent = validPair.getParentComponent();
+            IceMediaStream parentStream = parentComponent.getParentStream();
 
             // do not nominate pair if there is currently a nominated pair for
             // the component
-            if (validPair.getParentComponent().getParentStream().
-                validListContainsNomineeForComponent(validPair.getParentComponent()))
+            if (parentStream.validListContainsNomineeForComponent(parentComponent))
             {
                 logger.debug(() ->
                         "Keep-alive for pair: " + validPair.toShortString());


### PR DESCRIPTION
Nomination is blocked once something is nominated rather than waiting until something is selected.