### PR TITLE
Shut down STUN stack before removing streams from Agent.

### DIFF
--- a/src/main/java/org/ice4j/ice/Agent.java
+++ b/src/main/java/org/ice4j/ice/Agent.java
@@ -2382,6 +2382,9 @@ public class Agent
             terminate(IceProcessingState.TERMINATED);
         }
 
+        /* Stop all outstanding transactions */
+        getStunStack().shutDown();
+
         // Free its IceMediaStreams, Components and Candidates.
         boolean interrupted = false;
 
@@ -2405,8 +2408,6 @@ public class Agent
         }
         if (interrupted)
             Thread.currentThread().interrupt();
-
-        getStunStack().shutDown();
 
         logger.debug(() -> "ICE agent freed");
     }


### PR DESCRIPTION
Should fix NPEs being thrown during Agent.free().