### PR TITLE
Enable ephemeral port usage

### DIFF
--- a/src/main/java/org/ice4j/ice/harvest/AbstractUdpListener.java
+++ b/src/main/java/org/ice4j/ice/harvest/AbstractUdpListener.java
@@ -195,7 +195,7 @@ public abstract class AbstractUdpListener
     /**
      * Initializes a new <tt>SinglePortUdpHarvester</tt> instance which is to
      * bind on the specified local address.
-     * @param localAddress the address to bind to. If the port is 0 an ephemeral port will be chosen and the
+     * @param localAddress the address to bind to. If the port is 0 an ephemeral port will be chosen by the OS and the
      *                     AbstractUdpListener.localAddress will reflect the allocated port.
      * @throws IOException if initialization fails.
      */

--- a/src/main/java/org/ice4j/ice/harvest/AbstractUdpListener.java
+++ b/src/main/java/org/ice4j/ice/harvest/AbstractUdpListener.java
@@ -195,7 +195,8 @@ public abstract class AbstractUdpListener
     /**
      * Initializes a new <tt>SinglePortUdpHarvester</tt> instance which is to
      * bind on the specified local address.
-     * @param localAddress the address to bind to.
+     * @param localAddress the address to bind to. If the port is 0 an ephemeral port will be chosen and the
+     *                     AbstractUdpListener.localAddress will reflect the allocated port.
      * @throws IOException if initialization fails.
      */
     protected AbstractUdpListener(TransportAddress localAddress)

--- a/src/main/java/org/ice4j/ice/harvest/SinglePortUdpHarvester.java
+++ b/src/main/java/org/ice4j/ice/harvest/SinglePortUdpHarvester.java
@@ -101,7 +101,8 @@ public class SinglePortUdpHarvester
     /**
      * Initializes a new <tt>SinglePortUdpHarvester</tt> instance which is to
      * bind on the specified local address.
-     * @param localAddress the address to bind to.
+     * @param localAddress the address to bind to. If the port is 0 an ephemeral port is chosen by the OS and the
+     *                     SinglePortUdpHarvester.localAddress will reflect the allocated port number.
      * @throws IOException if initialization fails.
      */
     public SinglePortUdpHarvester(TransportAddress localAddress)

--- a/src/main/java/org/ice4j/ice/harvest/SinglePortUdpHarvester.java
+++ b/src/main/java/org/ice4j/ice/harvest/SinglePortUdpHarvester.java
@@ -109,7 +109,7 @@ public class SinglePortUdpHarvester
     {
         super(localAddress);
         logger.info("Initialized SinglePortUdpHarvester with address "
-                            + localAddress);
+                            + this.localAddress);
     }
 
     /**

--- a/src/test/java/org/ice4j/ice/harvest/SinglePortUdpHarvesterTest.java
+++ b/src/test/java/org/ice4j/ice/harvest/SinglePortUdpHarvesterTest.java
@@ -115,13 +115,17 @@ public class SinglePortUdpHarvesterTest
     }
 
     @Test
-    public void testBindWithPortZero() throws Exception {
+    public void testBindWithPortZero() throws Exception
+    {
         // Setup test fixture.
         final TransportAddress address = new TransportAddress("127.0.0.1", 0, Transport.UDP);
         SinglePortUdpHarvester harvester;
-        try {
+        try
+        {
             harvester = new SinglePortUdpHarvester(address);
-        } catch (BindException ex) {
+        }
+        catch (BindException ex)
+        {
             // This is not expected at this stage.
             // Rethrow as a different exception than the BindException, that is expected to be thrown later in
             // this test.

--- a/src/test/java/org/ice4j/ice/harvest/SinglePortUdpHarvesterTest.java
+++ b/src/test/java/org/ice4j/ice/harvest/SinglePortUdpHarvesterTest.java
@@ -101,7 +101,7 @@ public class SinglePortUdpHarvesterTest
         // Verify results.
         catch ( BindException ex )
         {
-            fail( "A bind exception should not have been thrown, as the original harvester was propertly closed.");
+            fail( "A bind exception should not have been thrown, as the original harvester was properly closed.");
         }
 
         // Tear down.

--- a/src/test/java/org/ice4j/ice/harvest/SinglePortUdpHarvesterTest.java
+++ b/src/test/java/org/ice4j/ice/harvest/SinglePortUdpHarvesterTest.java
@@ -113,4 +113,25 @@ public class SinglePortUdpHarvesterTest
             }
         }
     }
+
+    @Test
+    public void testBindWithPortZero() throws Exception {
+        // Setup test fixture.
+        final TransportAddress address = new TransportAddress("127.0.0.1", 0, Transport.UDP);
+        SinglePortUdpHarvester harvester;
+        try {
+            harvester = new SinglePortUdpHarvester(address);
+        } catch (BindException ex) {
+            // This is not expected at this stage.
+            // Rethrow as a different exception than the BindException, that is expected to be thrown later in
+            // this test.
+            throw new Exception("Test fixture is invalid.", ex);
+        }
+
+        assertFalse(harvester.localAddress.getPort() == 0,
+                "A random port number not equal to zero should have been chosen by the OS");
+
+        // Tear down
+        harvester.close();
+    }
 }


### PR DESCRIPTION
This enables using port=0 in AbstractUdpListener to indicate that a random, ephemeral port should be used instead of a configured port number.