### PR TITLE
Pull request to fix issue 244

### DIFF
--- a/src/main/java/org/ice4j/pseudotcp/PseudoTcpSocketImpl.java
+++ b/src/main/java/org/ice4j/pseudotcp/PseudoTcpSocketImpl.java
@@ -912,7 +912,8 @@ class PseudoTcpSocketImpl
         public int read(byte[] buffer, int offset, int length)
             throws IOException
         {
-            if (length == 0) {  
+            if (length == 0) 
+            {  
                 return 0;
             }
 

--- a/src/main/java/org/ice4j/pseudotcp/PseudoTcpSocketImpl.java
+++ b/src/main/java/org/ice4j/pseudotcp/PseudoTcpSocketImpl.java
@@ -912,6 +912,10 @@ class PseudoTcpSocketImpl
         public int read(byte[] buffer, int offset, int length)
             throws IOException
         {
+            if (length == 0) {  
+                return 0;
+            }
+
             long start = System.nanoTime();
             int read;
             while (true)


### PR DESCRIPTION
I added guard code for case when provided length is zero in PseudoTcpInputStream#read

Idk if guard code from length == 0 should be placed on lower level than PseudoTcpInputStream#read, it's for you to decide if it should be in PseudoTCPBase#recv (or lower)