### PR TITLE
fix: Add a null check.

### DIFF
--- a/src/main/java/org/ice4j/stack/Connector.java
+++ b/src/main/java/org/ice4j/stack/Connector.java
@@ -326,7 +326,15 @@ class Connector
         DatagramPacket datagramPacket
             = new DatagramPacket(message, 0, message.length, address);
 
-        sock.send(datagramPacket);
+        IceSocketWrapper sock = this.sock;
+        if (sock != null)
+        {
+            sock.send(datagramPacket);
+        }
+        else
+        {
+            logger.warning("Can not send message, Connector stopped.");
+        }
     }
 
     /**


### PR DESCRIPTION
org.ice4j.stack.StunClientTransaction$Retransmitter.run: A client tran retransmission failed
java.lang.NullPointerException
        at org.ice4j.stack.Connector.sendMessage(Connector.java:329)
        at org.ice4j.stack.NetAccessManager.sendMessage(NetAccessManager.java:635)
