### PR TITLE
log: Do not print stack trace

### DIFF
--- a/src/main/java/org/ice4j/ice/ConnectivityCheckClient.java
+++ b/src/main/java/org/ice4j/ice/ConnectivityCheckClient.java
@@ -21,7 +21,6 @@ import java.net.*;
 import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.*;
 
 import org.ice4j.*;
 import org.ice4j.attribute.*;
@@ -29,7 +28,6 @@ import org.ice4j.message.*;
 import org.ice4j.socket.*;
 import org.ice4j.stack.*;
 import org.ice4j.util.*;
-import org.jitsi.utils.logging2.*;
 import org.jitsi.utils.logging2.Logger;
 
 /**
@@ -344,9 +342,12 @@ class ConnectivityCheckClient
                         maxRetransmissions);
             if (logger.isTraceEnabled())
             {
-                logger.trace(
-                        "checking pair " + candidatePair + " tid " + tran);
+                logger.trace("checking pair " + candidatePair + " tid " + tran);
             }
+        }
+        catch (NetAccessManager.SocketNotFoundException e)
+        {
+            logger.info("Could not start connectivity check: " + e.getMessage());
         }
         catch (Exception ex)
         {

--- a/src/main/java/org/ice4j/stack/NetAccessManager.java
+++ b/src/main/java/org/ice4j/stack/NetAccessManager.java
@@ -42,7 +42,7 @@ import java.util.logging.*;
  * @author Boris Grozev
  * @author Yura Yaroshevich
  */
-class NetAccessManager
+public class NetAccessManager
     implements ErrorHandler
 {
     /**
@@ -628,10 +628,17 @@ class NetAccessManager
         Connector ap = getConnector(srcAddr, remoteAddr);
         if (ap == null)
         {
-            throw new IllegalArgumentException(
-                    "No socket found for " + srcAddr + "->" + remoteAddr);
+            throw new IllegalArgumentException("No socket found for " + srcAddr + "->" + remoteAddr);
         }
 
         ap.sendMessage(bytes, remoteAddr);
+    }
+
+    public class SocketNotFoundException extends IllegalArgumentException
+    {
+        private SocketNotFoundException(String message)
+        {
+            super(message);
+        }
     }
 }


### PR DESCRIPTION
when ConnectivityCheckClient fails to send due to missing socket.

This condition happens when SinglePortUdpListener is used and hasn't
received packets from the destination address yet.
