### PR TITLE
Could org.jitsi:ice4j:3.0-SNAPSHOT drop off redundant dependencies? 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,32 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>jitsi-utils</artifactId>
       <version>1.0-107-g566f8f8</version>
+      <exclusions>
+        <exclusion>
+          <groupId>net.java.dev.jna</groupId>
+          <artifactId>jna</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.j2objc</groupId>
+          <artifactId>j2objc-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>listenablefuture</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -72,36 +98,80 @@
       <artifactId>junit-platform-launcher</artifactId>
       <version>1.8.1</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+            <groupId>org.apiguardian</groupId>
+            <artifactId>apiguardian-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+            <groupId>org.apiguardian</groupId>
+            <artifactId>apiguardian-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+            <groupId>org.apiguardian</groupId>
+            <artifactId>apiguardian-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
         <groupId>io.kotest</groupId>
         <artifactId>kotest-assertions-core-jvm</artifactId>
         <version>${kotest.version}</version>
         <scope>test</scope>
+        <exclusions>
+            <exclusion>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-common</artifactId>
+            </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
         <groupId>io.kotest</groupId>
         <artifactId>kotest-runner-junit5-jvm</artifactId>
         <version>${kotest.version}</version>
         <scope>test</scope>
+        <exclusions>
+            <exclusion>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-suite-api</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.apiguardian</groupId>
+                <artifactId>apiguardian-api</artifactId>
+            </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jitsi</groupId>
       <artifactId>jicoco-test-kotlin</artifactId>
       <version>${jicoco.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+            <groupId>io.mockk</groupId>
+            <artifactId>mockk-common</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>io.mockk</groupId>
+            <artifactId>mockk-dsl</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
Hi! I found the pom file of project **_org.jitsi:ice4j:3.0-SNAPSHOT_** introduced **_68_** dependencies. However, among them, **_10_** libraries (**_14%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
com.google.j2objc:j2objc-annotations:jar:1.3:compile
io.mockk:mockk-dsl:jar:1.10.0:test
net.java.dev.jna:jna:jar:5.9.0:compile
com.google.errorprone:error_prone_annotations:jar:2.7.1:compile
com.google.code.findbugs:jsr305:jar:3.0.2:compile
org.apiguardian:apiguardian-api:jar:1.1.2:test
org.junit.platform:junit-platform-suite-api:jar:1.6.2:test
org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.5.31:compile
io.mockk:mockk-common:jar:1.10.0:test
## Outdated dependencies
org.junit.platform:junit-platform-suite-api:1.6.2 (**_1206_** days without maintenance)
com.google.j2objc:j2objc-annotations:1.3 (**_2383_** days without maintenance)

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_org.junit.platform:junit-platform-suite-api:jar:1.6.2:test_** incorporates an incompatible license ECLIPSE PUBLIC LICENSE V2.0 (ECLIPSE PUBLIC LICENSE V2.0 cannot be used by the project with license Apache-2.0). 2 of the redundant dependencies **_io.mockk:mockk-dsl:jar:1.10.0:test, org.apiguardian:apiguardian-api:jar:1.1.2:test_** induced dependency conflict in the dependency graph. As such, I suggest a refactoring operation for **_org.jitsi:ice4j:3.0-SNAPSHOT_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_org.jitsi:ice4j:3.0-SNAPSHOT_**’s maven tests.

Best regards