### PR TITLE
fix: Delegate getInputStream of PseudoTcpSocket

### DIFF
--- a/src/main/java/org/ice4j/pseudotcp/PseudoTcpSocket.java
+++ b/src/main/java/org/ice4j/pseudotcp/PseudoTcpSocket.java
@@ -258,6 +258,12 @@ public class PseudoTcpSocket extends Socket
     }
 
     @Override
+    public InputStream getInputStream() throws IOException
+    {
+        return socketImpl.getInputStream();
+    }
+
+    @Override
     public OutputStream getOutputStream() throws IOException
     {
         return socketImpl.getOutputStream();


### PR DESCRIPTION
Hello,

this is a small fix to allow writing data to pseudo TCP sockets. I presume it was an oversight that this method was not delegated.