### PR TITLE
Don't start multiple PaceMakers for a single CheckList.

### DIFF
--- a/src/main/java/org/ice4j/ice/CheckList.java
+++ b/src/main/java/org/ice4j/ice/CheckList.java
@@ -21,6 +21,7 @@ import org.jitsi.utils.logging2.*;
 
 import java.beans.*;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * A check list is a list of <tt>CandidatePair</tt>s with a state (i.e. a
@@ -56,6 +57,11 @@ public class CheckList
      * The state of this check list.
      */
     private CheckListState state = CheckListState.RUNNING;
+
+    /**
+     * Whether a PaceMaker has been started for this check list.
+     */
+    private AtomicBoolean paceMakerStarted = new AtomicBoolean(false);
 
     /**
      * The <tt>triggeredCheckQueue</tt> is a FIFO queue containing candidate
@@ -603,5 +609,10 @@ public class CheckList
     public IceMediaStream getParentStream()
     {
         return parentStream;
+    }
+
+    public boolean shouldStartPaceMaker()
+    {
+        return paceMakerStarted.compareAndSet(false, true);
     }
 }

--- a/src/main/java/org/ice4j/ice/ConnectivityCheckClient.java
+++ b/src/main/java/org/ice4j/ice/ConnectivityCheckClient.java
@@ -165,6 +165,12 @@ class ConnectivityCheckClient
      */
     public void startChecks(CheckList checkList)
     {
+        if (!checkList.shouldStartPaceMaker())
+        {
+            logger.debug("Checks for " + checkList.getName() + " already started");
+            return;
+        }
+        logger.debug("Start connectivity checks for " + checkList.getName());
         synchronized (paceMakers)
         {
             if (stopped)
@@ -925,10 +931,18 @@ class ConnectivityCheckClient
         {
             CandidatePair pairToCheck = checkList.popTriggeredCheck();
 
+            if (pairToCheck != null)
+            {
+                logger.trace("Starting triggered check " + pairToCheck.toRedactedString());
+            }
             //if there are no triggered checks, go for an ordinary one.
             if (pairToCheck == null)
             {
                 pairToCheck = checkList.getNextOrdinaryPairToCheck();
+                if (pairToCheck != null)
+                {
+                    logger.trace("Starting ordinary check " + pairToCheck.toRedactedString());
+                }
             }
 
             if (pairToCheck != null)


### PR DESCRIPTION
Fixing this means we no longer send two simultaneous checks for the same candidate pair, if it was triggered before connectivity checks started.