### PR TITLE
fix: Fail early if IMDS returns an error.

### DIFF
--- a/src/main/java/org/ice4j/ice/harvest/AwsCandidateHarvester.java
+++ b/src/main/java/org/ice4j/ice/harvest/AwsCandidateHarvester.java
@@ -265,6 +265,10 @@ public class AwsCandidateHarvester
             builder.setHeader(header.getKey(), header.getValue());
         }
         HttpResponse<String> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() != 200)
+        {
+            throw new Exception("Failed to fetch " + url + ". Response code: " + response.statusCode());
+        }
         return response.body();
     }
 }


### PR DESCRIPTION
This catches errors earlier on OCI for example, where the PUT request
returns 405.
