### PR TITLE
fix: Switch to the selected pair once it is nominated.

### DIFF
--- a/src/main/java/org/ice4j/ice/Component.java
+++ b/src/main/java/org/ice4j/ice/Component.java
@@ -19,7 +19,6 @@ package org.ice4j.ice;
 
 import java.beans.*;
 import java.io.*;
-import java.lang.ref.*;
 import java.net.*;
 import java.util.*;
 import java.util.concurrent.*;
@@ -164,13 +163,7 @@ public class Component
     /**
      * The remote address of the last received payload packet.
      */
-    private SocketAddress lastReceivedFrom = null;
-
-    /**
-     * A reference to the last {@link CandidatePair} that was used to send a packet to. If the remote address that
-     * we receive payload from changes, this reference is cleared.
-     */
-    private WeakReference<CandidatePair> lastUsedPair = new WeakReference<>(null);
+    private volatile SocketAddress lastReceivedFrom = null;
 
     /**
      * Creates a new <tt>Component</tt> with the specified <tt>componentID</tt>
@@ -1214,18 +1207,14 @@ public class Component
     }
 
     /**
-     * Send a packet to the remote side. Uses the last used candidate pair to find the right socket and remote address.
+     * Send a packet to the remote side. Uses {@link #findPair(SocketAddress)} to find the right socket and remote
+     * address. The pair is determined for every packet (rather than cached), so that we switch to the selected pair
+     * as soon as one is selected, even if we had been sending to a different pair before that.
      */
     public void send(byte[] buffer, int offset, int length)
             throws IOException
     {
-        CandidatePair pair = lastUsedPair.get();
-        if (pair == null)
-        {
-            pair = findPair(lastReceivedFrom);
-            lastUsedPair = new WeakReference<>(pair);
-        }
-
+        CandidatePair pair = findPair(lastReceivedFrom);
         if (pair == null)
         {
             throw new IOException("No valid pair.");
@@ -1242,6 +1231,12 @@ public class Component
         addressAndSocket.socket.send(p);
     }
 
+    /**
+     * Finds the {@link CandidatePair} to use for sending: the keep-alive pair matching {@code remoteAddress} if
+     * {@link AgentConfig#getSendToLastReceivedFromAddress()} is enabled, otherwise the selected pair. If no pair has
+     * been selected yet (e.g. we are sending DTLS as soon as the first pair is validated) falls back to a pair from
+     * the valid list, which is not necessarily the pair that will eventually be selected.
+     */
     private CandidatePair findPair(SocketAddress remoteAddress)
     {
         CandidatePair pair = null;
@@ -1307,12 +1302,7 @@ public class Component
 
         try
         {
-            SocketAddress remoteAddress = buffer.getRemoteAddress();
-            if (remoteAddress == null || !remoteAddress.equals(lastReceivedFrom))
-            {
-                lastUsedPair = new WeakReference<>(null);
-                lastReceivedFrom = buffer.getRemoteAddress();
-            }
+            lastReceivedFrom = buffer.getRemoteAddress();
             bufferCallback.handleBuffer(buffer);
         }
         catch (Exception e)

--- a/src/test/java/org/ice4j/ice/ComponentSendTest.java
+++ b/src/test/java/org/ice4j/ice/ComponentSendTest.java
@@ -1,0 +1,213 @@
+/*
+ * ice4j, the OpenSource Java Solution for NAT and Firewall Traversal.
+ *
+ * Copyright @ 2026 8x8, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ice4j.ice;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.*;
+import java.net.*;
+import java.nio.charset.*;
+
+import org.ice4j.*;
+import org.ice4j.socket.*;
+import org.junit.jupiter.api.*;
+
+/**
+ * Tests the choice of {@link CandidatePair} in {@link Component#send(byte[], int, int)}.
+ */
+public class ComponentSendTest
+{
+    private static final InetAddress LOOPBACK = InetAddress.getLoopbackAddress();
+
+    private Agent agent;
+    private IceMediaStream stream;
+    private Component component;
+
+    /** The local socket which the component sends from. */
+    private DatagramSocket localSocket;
+    /** Sockets standing in for two different remote addresses of the same peer. */
+    private DatagramSocket remoteA;
+    private DatagramSocket remoteB;
+
+    private CandidatePair pairA;
+    private CandidatePair pairB;
+
+    @BeforeEach
+    public void setUp()
+        throws IOException
+    {
+        localSocket = new DatagramSocket(0, LOOPBACK);
+        remoteA = new DatagramSocket(0, LOOPBACK);
+        remoteB = new DatagramSocket(0, LOOPBACK);
+        remoteA.setSoTimeout(200);
+        remoteB.setSoTimeout(200);
+
+        agent = new Agent("test", null);
+        agent.setControlling(true);
+        stream = agent.createMediaStream("stream");
+        // Create the component directly on the stream rather than via Agent.createComponent(), which would harvest
+        // candidates on the real network interfaces. We only need the loopback host candidate created below.
+        component = stream.createComponent(KeepAliveStrategy.SELECTED_ONLY, false);
+
+        HostCandidate local = new HostCandidate(new IceUdpSocketWrapper(localSocket), component);
+        component.addLocalCandidate(local);
+
+        // B has a higher priority than A, so it sorts first in the valid list.
+        RemoteCandidate remoteCandidateA = createRemoteCandidate(remoteA, 1000);
+        RemoteCandidate remoteCandidateB = createRemoteCandidate(remoteB, 2000);
+
+        pairA = agent.createCandidatePair(local, remoteCandidateA);
+        pairB = agent.createCandidatePair(local, remoteCandidateB);
+        assertTrue(pairB.getPriority() > pairA.getPriority());
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        if (agent != null)
+        {
+            agent.free();
+        }
+        for (DatagramSocket socket : new DatagramSocket[] { localSocket, remoteA, remoteB })
+        {
+            if (socket != null)
+            {
+                socket.close();
+            }
+        }
+    }
+
+    private RemoteCandidate createRemoteCandidate(DatagramSocket socket, long priority)
+    {
+        return new RemoteCandidate(
+                new TransportAddress(LOOPBACK, socket.getLocalPort(), Transport.UDP),
+                component,
+                CandidateType.PEER_REFLEXIVE_CANDIDATE,
+                "foundation" + priority,
+                priority,
+                null);
+    }
+
+    private void send(String payload)
+        throws IOException
+    {
+        byte[] bytes = payload.getBytes(StandardCharsets.UTF_8);
+        component.send(bytes, 0, bytes.length);
+    }
+
+    private static String receive(DatagramSocket socket)
+        throws IOException
+    {
+        DatagramPacket p = new DatagramPacket(new byte[1500], 1500);
+        socket.receive(p);
+        return new String(p.getData(), p.getOffset(), p.getLength(), StandardCharsets.UTF_8);
+    }
+
+    private static void assertNothingReceived(DatagramSocket socket)
+        throws IOException
+    {
+        DatagramPacket p = new DatagramPacket(new byte[1500], 1500);
+        try
+        {
+            socket.receive(p);
+            fail("Unexpected packet received on " + socket.getLocalSocketAddress());
+        }
+        catch (SocketTimeoutException expected)
+        {
+        }
+    }
+
+    /**
+     * Before any pair is selected we may fall back to sending to a valid pair. Once a pair is selected, we must
+     * switch to it, even if the pair we used before was different.
+     */
+    @Test
+    public void testSwitchesToSelectedPairAfterNomination()
+        throws IOException
+    {
+        // A is validated first, then B (which has a higher priority).
+        pairA.setStateSucceeded();
+        stream.addToValidList(pairA);
+        pairB.setStateSucceeded();
+        stream.addToValidList(pairB);
+        assertNull(component.getSelectedPair());
+
+        // Sending before nomination falls back to the highest-priority valid pair.
+        send("pre-nomination");
+        assertEquals("pre-nomination", receive(remoteB));
+        assertNothingReceived(remoteA);
+
+        // Now A is nominated and selected.
+        component.setSelectedPair(pairA);
+
+        send("post-nomination");
+        assertEquals("post-nomination", receive(remoteA));
+        assertNothingReceived(remoteB);
+
+        // And it stays on the selected pair.
+        send("post-nomination-2");
+        assertEquals("post-nomination-2", receive(remoteA));
+        assertNothingReceived(remoteB);
+    }
+
+    /**
+     * When there is a selected pair from the start, it is used.
+     */
+    @Test
+    public void testSendsToSelectedPair()
+        throws IOException
+    {
+        pairA.setStateSucceeded();
+        stream.addToValidList(pairA);
+        pairB.setStateSucceeded();
+        stream.addToValidList(pairB);
+        component.setSelectedPair(pairA);
+
+        send("hello");
+        assertEquals("hello", receive(remoteA));
+        assertNothingReceived(remoteB);
+    }
+
+    /**
+     * If the selected pair changes, sending follows it.
+     */
+    @Test
+    public void testFollowsSelectedPairChange()
+        throws IOException
+    {
+        pairA.setStateSucceeded();
+        stream.addToValidList(pairA);
+        pairB.setStateSucceeded();
+        stream.addToValidList(pairB);
+
+        component.setSelectedPair(pairA);
+        send("to-a");
+        assertEquals("to-a", receive(remoteA));
+
+        component.setSelectedPair(pairB);
+        send("to-b");
+        assertEquals("to-b", receive(remoteB));
+        assertNothingReceived(remoteA);
+    }
+
+    @Test
+    public void testNoValidPair()
+    {
+        assertThrows(IOException.class, () -> send("nowhere"));
+    }
+}


### PR DESCRIPTION
Fixes jitsi/jitsi-videobridge#2427.

## Problem

Since #305, `Component.send()` cached the pair it last used (`lastUsedPair`). The cache was only cleared when the remote address of received payload changed, never when the selected pair was set.

The videobridge starts DTLS as soon as the first pair is validated, before nomination. At that point `getSelectedPair()` is null, so `findPair()` falls back to `getValidPair()`, which returns the highest-priority pair in the valid list. That pair was then cached and used for the rest of the session, even after a different pair was nominated.

In the report, a client reachable over two paths (public NAT and VPN) validated the public pair first, then the VPN pair a millisecond later. The VPN pair has a higher priority (host local candidate vs. srflx), so it sorted first in the valid list. The DTLS ServerHello went out between those two events and the nomination of the public pair, so the VPN pair was cached. The client kept sending on the public pair so the cache never cleared. STUN keepalives went to the nominated pair (they don't go through `Component.send()`), so ICE looked healthy on both sides while all media went to the other path. The client then got a 403 on its consent check for the VPN pair (#304), dropped that connection, and stopped receiving anything.

## Fix

Remove the cache and determine the pair on every send, as before #305. The lookup is a memoized config read plus, only when `send-to-last-received-from-address` is enabled, a scan of the keep-alive pairs. Measured against the rest of the send path (packet allocation and the syscall) this is negligible, and with the default `selected_only` strategy the set has one entry.

`findPair()` is otherwise unchanged; `lastReceivedFrom` is now volatile since it is written on the receive thread and read on the send thread.

## Test

`ComponentSendTest` reproduces the scenario: two pairs validated with the higher-priority one second, a send before nomination, then nomination of the other pair. The two nomination tests fail against master with a receive timeout on the selected pair's socket and pass with this change.

## Follow-ups (not in this PR)

- Pairs are never removed from `keepAlivePairs`, so a pair that goes FAILED keeps generating consent-freshness retransmissions indefinitely. Pruning FAILED pairs is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
