### PR TITLE
Keep-alive pair maintenance: dedup, pruning, re-checking, cap

### DIFF
--- a/src/main/java/org/ice4j/ice/Agent.java
+++ b/src/main/java/org/ice4j/ice/Agent.java
@@ -1723,7 +1723,8 @@ public class Agent
             if (connCheckClient.isStopped())
             {
                 // Connectivity checks are over, so the triggered check which we would schedule below would never be
-                // sent (and the pair would be left in the Waiting state forever). Just decide whether to respond.
+                // sent (and the pair would be left in the Waiting state forever).
+                recheckPairAfterTermination(knownPair);
                 return shouldRespondAfterTermination(knownPair);
             }
         }
@@ -1791,6 +1792,60 @@ public class Agent
                     knownPair.toRedactedString() + " when ICE processing is terminated");
         }
         return respond;
+    }
+
+    /**
+     * Handles a connectivity check received, after ICE processing has terminated, on a known pair which is not in the
+     * SUCCEEDED state. If the pair is one we would keep alive had it succeeded (see
+     * {@link Component#wantsKeepAlive(CandidatePair)}), the remote side checking it suggests that it wants to use it,
+     * e.g. because it has become available again after it failed and was removed from the keep-alive pairs. Add it to
+     * the keep-alive pairs and check it: if our check succeeds the pair becomes SUCCEEDED and usable; otherwise it
+     * will be removed again once it has been failed for long enough.
+     * <p>
+     * This is rate-limited by the fact that the pair is only re-checked when it is added to the keep-alive set, and
+     * a pair is not re-added for a while after it has been removed.
+     */
+    private void recheckPairAfterTermination(CandidatePair pair)
+    {
+        Component component = pair.getParentComponent();
+        if (!performConsentFreshness)
+        {
+            // Without consent freshness checks the pair could never become SUCCEEDED (or FAILED) again.
+            return;
+        }
+        if (component.wantsKeepAlive(pair) && component.addKeepAlivePair(pair))
+        {
+            logger.info("Re-checking pair " + pair.toRedactedShortString()
+                    + " after receiving a connectivity check on it.");
+            sendKeepAlive(pair);
+        }
+    }
+
+    /**
+     * Sends a keep-alive to a pair: a consent freshness check (a STUN Binding request) if consent freshness is
+     * enabled, and a STUN Binding indication otherwise.
+     */
+    private void sendKeepAlive(CandidatePair pair)
+    {
+        if (performConsentFreshness)
+        {
+            TransactionID transactionID = connCheckClient.startCheckForPair(
+                pair,
+                (int) config.getConsentFreshnessOriginalWaitInterval().toMillis(),
+                (int) config.getConsentFreshnessMaxWaitInterval().toMillis(),
+                config.getMaxConsentFreshnessRetransmissions());
+            if (transactionID == null)
+            {
+                // The check could not be sent (e.g. the socket is gone). Treat it like a check which timed out, so
+                // that the pair is eventually removed from the keep-alive pairs.
+                logger.debug(() -> "Failed to send keep-alive for pair " + pair.toRedactedShortString());
+                pair.setStateFailed();
+            }
+        }
+        else
+        {
+            connCheckClient.sendBindingIndicationForPair(pair);
+        }
     }
 
     /**
@@ -2667,13 +2722,6 @@ public class Agent
     private final class StunKeepAliveRunner extends PeriodicRunnable
     {
         private final long consentFreshnessInterval = config.getConsentFreshnessInterval().toMillis();
-        private final int originalConsentFreshnessWaitInterval
-                = (int) config.getConsentFreshnessOriginalWaitInterval().toMillis();
-
-        private final int maxConsentFreshnessWaitInterval
-                = (int) config.getConsentFreshnessMaxWaitInterval().toMillis();
-
-        private final int consentFreshnessMaxRetransmissions = config.getMaxConsentFreshnessRetransmissions();
 
         private int keepAliveSent = 0;
 
@@ -2729,19 +2777,7 @@ public class Agent
                     {
                         if (pair != null)
                         {
-                            if (performConsentFreshness)
-                            {
-                                connCheckClient.startCheckForPair(
-                                    pair,
-                                    originalConsentFreshnessWaitInterval,
-                                    maxConsentFreshnessWaitInterval,
-                                    consentFreshnessMaxRetransmissions);
-                            }
-                            else
-                            {
-                                connCheckClient
-                                    .sendBindingIndicationForPair(pair);
-                            }
+                            Agent.this.sendKeepAlive(pair);
                         }
                     }
                 }

--- a/src/main/java/org/ice4j/ice/Agent.java
+++ b/src/main/java/org/ice4j/ice/Agent.java
@@ -1703,21 +1703,9 @@ public class Agent
                     checkListStatesUpdated();
                 }
 
-                if (getState() == IceProcessingState.TERMINATED
-                        && knownPair.getParentComponent().getKeepAliveStrategy() != KeepAliveStrategy.ALL_SUCCEEDED)
+                if (getState() == IceProcessingState.TERMINATED)
                 {
-                    // After we've terminated, only respond for the selected pair
-                    CandidatePair selected
-                            = getSelectedPair(knownPair.getParentComponent().getParentStream().getName());
-                    boolean respond = selected != null
-                            && knownPair.getRemoteCandidate().getTransportAddress().equals(
-                                    selected.getRemoteCandidate().getTransportAddress());
-                    if (!respond)
-                    {
-                        logger.warn("Received connectivity check on non-selected pair " +
-                                knownPair.toRedactedString() + " when ICE processing is terminated");
-                    }
-                    return respond;
+                    return shouldRespondAfterTermination(knownPair);
                 }
                 return true;
             }
@@ -1730,6 +1718,13 @@ public class Agent
                     = knownPair.getConnectivityCheckTransaction();
 
                 getStunStack().cancelTransaction(checkTransaction);
+            }
+
+            if (connCheckClient.isStopped())
+            {
+                // Connectivity checks are over, so the triggered check which we would schedule below would never be
+                // sent (and the pair would be left in the Waiting state forever). Just decide whether to respond.
+                return shouldRespondAfterTermination(knownPair);
             }
         }
         else
@@ -1776,6 +1771,26 @@ public class Agent
             connCheckClient.startChecks(checkList);
 
         return true;
+    }
+
+    /**
+     * Decides whether to respond to a connectivity check received on a known pair after ICE processing has
+     * terminated. We only respond to checks on pairs whose remote address we are keeping alive (with the
+     * {@link KeepAliveStrategy#SELECTED_ONLY} strategy this is just the selected pair). A remote endpoint which checks
+     * a pair we do not keep alive (e.g. because its address has changed due to a NAT rebinding, or because the pair
+     * is not among the ones we keep alive) fails its consent checks on that pair and stops using it, or restarts ICE,
+     * instead of continuing on a pair we will not use.
+     */
+    private boolean shouldRespondAfterTermination(CandidatePair knownPair)
+    {
+        boolean respond = knownPair.getParentComponent().hasKeepAlivePairForRemoteAddress(
+                knownPair.getRemoteCandidate().getTransportAddress());
+        if (!respond)
+        {
+            logger.warn("Received connectivity check on non-keep-alive pair " +
+                    knownPair.toRedactedString() + " when ICE processing is terminated");
+        }
+        return respond;
     }
 
     /**

--- a/src/main/java/org/ice4j/ice/Component.java
+++ b/src/main/java/org/ice4j/ice/Component.java
@@ -170,10 +170,15 @@ public class Component
     private final Duration failedKeepAlivePairTimeout = AgentConfig.config.getKeepAliveFailedPairTimeout();
 
     /**
-     * The time at which pairs were removed from {@link #keepAlivePairs} because they had been failed for too long.
-     * Such a pair is not added again (for re-checking) until {@link #failedKeepAlivePairTimeout} has passed.
+     * The time at which pairs were removed from {@link #keepAlivePairs} because they had been failed for too long (or
+     * evicted). Such a pair is not added again (for re-checking) until {@link #failedKeepAlivePairTimeout} has passed.
      */
     private final Map<CandidatePair, Instant> keepAlivePairsRemovedAt = new ConcurrentHashMap<>();
+
+    /**
+     * The maximum number of pairs in {@link #keepAlivePairs}. Zero or negative means no limit.
+     */
+    private final int maxKeepAlivePairs = AgentConfig.config.getMaxKeepAlivePairs();
 
     /**
      * The clock used to measure how long keep-alive pairs have been failed. Replaceable for tests.
@@ -1070,12 +1075,26 @@ public class Component
                     existing -> !existing.equals(pair) && isEquivalentForKeepAlive(existing, pair));
             }
             keepAlivePairs.add(pair);
+
+            // The selected pair is always added. Make room for it if necessary.
+            while (maxKeepAlivePairs > 0 && keepAlivePairs.size() > maxKeepAlivePairs)
+            {
+                CandidatePair evict = findKeepAlivePairToEvict();
+                if (evict == null)
+                {
+                    break;
+                }
+                removeKeepAlivePair(evict, "to make room for the selected pair.");
+            }
         }
     }
 
     /**
      * Adds {@code pair} to the set of keep-alive pairs, unless the set already contains it or a pair equivalent to it
-     * (see {@link #isEquivalentForKeepAlive(CandidatePair, CandidatePair)}).
+     * (see {@link #isEquivalentForKeepAlive(CandidatePair, CandidatePair)}), or the set is full and no pair can be
+     * evicted to make room. A failed pair can always be evicted. A succeeded pair can only be evicted for a pair which
+     * has succeeded and has a higher priority, so that remote peers can not displace working pairs by advertising
+     * high-priority candidates for pairs which have not succeeded.
      * @return {@code true} if the pair was added.
      */
     boolean addKeepAlivePair(CandidatePair pair)
@@ -1109,6 +1128,22 @@ public class Component
                 }
             }
 
+            if (maxKeepAlivePairs > 0 && keepAlivePairs.size() >= maxKeepAlivePairs)
+            {
+                CandidatePair evict = findKeepAlivePairToEvict();
+                boolean canEvict = evict != null
+                    && (keepAlivePairsFailedSince.containsKey(evict)
+                        || (pair.getState() == CandidatePairState.SUCCEEDED
+                            && evict.getPriority() < pair.getPriority()));
+                if (!canEvict)
+                {
+                    logger.debug(() -> "Not adding keep-alive pair " + pair.toRedactedShortString()
+                            + ", already keeping alive " + keepAlivePairs.size() + " pairs.");
+                    return false;
+                }
+                removeKeepAlivePair(evict, "to make room for " + pair.toRedactedShortString());
+            }
+
             keepAlivePairs.add(pair);
             keepAlivePairsRemovedAt.remove(pair);
             if (pair.getState() == CandidatePairState.FAILED)
@@ -1122,6 +1157,58 @@ public class Component
             }
             return true;
         }
+    }
+
+    /**
+     * Removes a pair from the set of keep-alive pairs. Must be called with the lock on {@link #keepAlivePairs} held.
+     * @param reason a description of the reason for the removal, for logging.
+     */
+    private void removeKeepAlivePair(CandidatePair pair, String reason)
+    {
+        keepAlivePairs.remove(pair);
+        keepAlivePairsFailedSince.remove(pair);
+        keepAlivePairsRemovedAt.put(pair, clock.instant());
+        logger.info("Removing keep-alive pair " + pair.toRedactedShortString() + " " + reason);
+    }
+
+    /**
+     * Finds the keep-alive pair to evict when the set is full: a currently failed pair if there is one (the one which
+     * failed first), otherwise the pair with the lowest priority. The selected pair is never evicted.
+     * @return the pair to evict, or {@code null} if there is no candidate.
+     */
+    private CandidatePair findKeepAlivePairToEvict()
+    {
+        CandidatePair evict = null;
+        Instant evictFailedSince = null;
+        for (CandidatePair candidate : keepAlivePairs)
+        {
+            if (candidate.equals(selectedPair))
+            {
+                continue;
+            }
+            Instant failedSince = keepAlivePairsFailedSince.get(candidate);
+            boolean better;
+            if (evict == null)
+            {
+                better = true;
+            }
+            else if (failedSince != null || evictFailedSince != null)
+            {
+                // Prefer to evict failed pairs, and among those the one which failed first.
+                better = failedSince != null
+                    && (evictFailedSince == null || failedSince.isBefore(evictFailedSince));
+            }
+            else
+            {
+                better = candidate.getPriority() < evict.getPriority();
+            }
+            if (better)
+            {
+                evict = candidate;
+                evictFailedSince = failedSince;
+            }
+        }
+        return evict;
     }
 
     /**
@@ -1156,11 +1243,7 @@ public class Component
             Duration failedFor = Duration.between(failedSince, now);
             if (failedFor.compareTo(failedKeepAlivePairTimeout) >= 0)
             {
-                keepAlivePairs.remove(pair);
-                keepAlivePairsFailedSince.remove(pair);
-                keepAlivePairsRemovedAt.put(pair, now);
-                logger.info("Removing keep-alive pair " + pair.toRedactedShortString()
-                        + ", failed for " + failedFor.toMillis() + " ms.");
+                removeKeepAlivePair(pair, "failed for " + failedFor.toMillis() + " ms.");
             }
         }
     }

--- a/src/main/java/org/ice4j/ice/Component.java
+++ b/src/main/java/org/ice4j/ice/Component.java
@@ -1151,6 +1151,22 @@ public class Component
     }
 
     /**
+     * @return {@code true} if one of the pairs which this component keeps alive has {@code remoteAddress} as its
+     * remote address.
+     */
+    boolean hasKeepAlivePairForRemoteAddress(TransportAddress remoteAddress)
+    {
+        for (CandidatePair pair : keepAlivePairs)
+        {
+            if (pair.getRemoteCandidate().getTransportAddress().equals(remoteAddress))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Two pairs are equivalent for the purpose of keep-alives when they use the same local socket (i.e. their local
      * candidates have the same base) to reach the same remote address. This is the case for the pair with a host
      * candidate and the pair with a server reflexive (or otherwise mapped) candidate derived from it. Keeping both

--- a/src/main/java/org/ice4j/ice/Component.java
+++ b/src/main/java/org/ice4j/ice/Component.java
@@ -151,7 +151,8 @@ public class Component
     private final KeepAliveStrategy keepAliveStrategy;
 
     /**
-     * The set of pairs which this component wants to keep alive.
+     * The set of pairs which this component wants to keep alive. Modifications are synchronized on the set itself (so
+     * that compound operations such as check-then-add are atomic), while iteration is lock-free.
      */
     private final Set<CandidatePair> keepAlivePairs = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
@@ -1025,13 +1026,71 @@ public class Component
      */
     protected void setSelectedPair(CandidatePair pair)
     {
-        if (keepAliveStrategy == KeepAliveStrategy.SELECTED_ONLY)
+        synchronized (keepAlivePairs)
         {
-            keepAlivePairs.clear();
-        }
-        keepAlivePairs.add(pair);
+            // Set the selected pair before adding it to the set, so that it is recognized as selected by any
+            // concurrent operation on the set.
+            this.selectedPair = pair;
 
-        this.selectedPair = pair;
+            if (keepAliveStrategy == KeepAliveStrategy.SELECTED_ONLY)
+            {
+                keepAlivePairs.clear();
+            }
+            else
+            {
+                // The selected pair takes the place of any equivalent pair (e.g. the host pair when the selected pair
+                // uses the mapped address of the same socket).
+                keepAlivePairs.removeIf(
+                    existing -> !existing.equals(pair) && isEquivalentForKeepAlive(existing, pair));
+            }
+            keepAlivePairs.add(pair);
+        }
+    }
+
+    /**
+     * Adds {@code pair} to the set of keep-alive pairs, unless the set already contains it or a pair equivalent to it
+     * (see {@link #isEquivalentForKeepAlive(CandidatePair, CandidatePair)}).
+     * @return {@code true} if the pair was added.
+     */
+    private boolean addKeepAlivePair(CandidatePair pair)
+    {
+        synchronized (keepAlivePairs)
+        {
+            if (keepAlivePairs.contains(pair))
+            {
+                return false;
+            }
+            for (CandidatePair existing : keepAlivePairs)
+            {
+                if (isEquivalentForKeepAlive(existing, pair))
+                {
+                    logger.debug(() -> "Not adding keep-alive pair " + pair.toRedactedShortString()
+                            + ", equivalent to " + existing.toRedactedShortString());
+                    return false;
+                }
+            }
+            keepAlivePairs.add(pair);
+            return true;
+        }
+    }
+
+    /**
+     * Two pairs are equivalent for the purpose of keep-alives when they use the same local socket (i.e. their local
+     * candidates have the same base) to reach the same remote address. This is the case for the pair with a host
+     * candidate and the pair with a server reflexive (or otherwise mapped) candidate derived from it. Keeping both
+     * alive is redundant.
+     */
+    private static boolean isEquivalentForKeepAlive(CandidatePair a, CandidatePair b)
+    {
+        return getBaseAddress(a).equals(getBaseAddress(b))
+            && a.getRemoteCandidate().getTransportAddress().equals(b.getRemoteCandidate().getTransportAddress());
+    }
+
+    private static TransportAddress getBaseAddress(CandidatePair pair)
+    {
+        LocalCandidate local = pair.getLocalCandidate();
+        LocalCandidate base = local.getBase();
+        return (base != null ? base : local).getTransportAddress();
     }
 
     /**
@@ -1195,9 +1254,9 @@ public class Component
             }
         }
 
-        if (addToKeepAlive && !keepAlivePairs.contains(pair))
+        if (addToKeepAlive)
         {
-            keepAlivePairs.add(pair);
+            addKeepAlivePair(pair);
         }
     }
 

--- a/src/main/java/org/ice4j/ice/Component.java
+++ b/src/main/java/org/ice4j/ice/Component.java
@@ -170,6 +170,12 @@ public class Component
     private final Duration failedKeepAlivePairTimeout = AgentConfig.config.getKeepAliveFailedPairTimeout();
 
     /**
+     * The time at which pairs were removed from {@link #keepAlivePairs} because they had been failed for too long.
+     * Such a pair is not added again (for re-checking) until {@link #failedKeepAlivePairTimeout} has passed.
+     */
+    private final Map<CandidatePair, Instant> keepAlivePairsRemovedAt = new ConcurrentHashMap<>();
+
+    /**
      * The clock used to measure how long keep-alive pairs have been failed. Replaceable for tests.
      */
     private Clock clock = Clock.systemUTC();
@@ -919,6 +925,7 @@ public class Component
         getParentStream().removePairStateChangeListener(this);
         keepAlivePairs.clear();
         keepAlivePairsFailedSince.clear();
+        keepAlivePairsRemovedAt.clear();
         if (componentSocket != null)
         {
             componentSocket.close();
@@ -1071,7 +1078,7 @@ public class Component
      * (see {@link #isEquivalentForKeepAlive(CandidatePair, CandidatePair)}).
      * @return {@code true} if the pair was added.
      */
-    private boolean addKeepAlivePair(CandidatePair pair)
+    boolean addKeepAlivePair(CandidatePair pair)
     {
         synchronized (keepAlivePairs)
         {
@@ -1088,11 +1095,26 @@ public class Component
                     return false;
                 }
             }
+            Instant now = clock.instant();
+            if (pair.getState() != CandidatePairState.SUCCEEDED)
+            {
+                // A pair which has not succeeded is added in order to re-check it. Don't do that too often for a
+                // pair which we have recently removed.
+                keepAlivePairsRemovedAt.values().removeIf(t -> !t.plus(failedKeepAlivePairTimeout).isAfter(now));
+                if (keepAlivePairsRemovedAt.containsKey(pair))
+                {
+                    logger.debug(() -> "Not adding keep-alive pair " + pair.toRedactedShortString()
+                            + ", it was recently removed.");
+                    return false;
+                }
+            }
+
             keepAlivePairs.add(pair);
+            keepAlivePairsRemovedAt.remove(pair);
             if (pair.getState() == CandidatePairState.FAILED)
             {
                 // A pair which is added while already failed gets the full timeout from now.
-                keepAlivePairsFailedSince.put(pair, clock.instant());
+                keepAlivePairsFailedSince.put(pair, now);
             }
             else
             {
@@ -1136,6 +1158,7 @@ public class Component
             {
                 keepAlivePairs.remove(pair);
                 keepAlivePairsFailedSince.remove(pair);
+                keepAlivePairsRemovedAt.put(pair, now);
                 logger.info("Removing keep-alive pair " + pair.toRedactedShortString()
                         + ", failed for " + failedFor.toMillis() + " ms.");
             }
@@ -1148,6 +1171,29 @@ public class Component
     void setClock(Clock clock)
     {
         this.clock = Objects.requireNonNull(clock);
+    }
+
+    /**
+     * @return {@code true} if this component's keep-alive strategy calls for keeping {@code pair} alive (once it
+     * succeeds), not counting the selected pair which is always kept alive.
+     */
+    boolean wantsKeepAlive(CandidatePair pair)
+    {
+        switch (keepAliveStrategy)
+        {
+        case ALL_SUCCEEDED:
+            return true;
+        case SELECTED_AND_TCP:
+            Transport transport = pair.getLocalCandidate().getTransport();
+            // Pairs with a remote TCP port 9 cannot be checked. Instead, the corresponding pair with the peer
+            // reflexive candidate needs to be checked. However, we observe such pairs transitioning into the SUCCEEDED
+            // state. Ignore them.
+            return (transport == Transport.TCP || transport == Transport.SSLTCP)
+                && pair.getRemoteCandidate().getTransportAddress().getPort() != 9;
+        case SELECTED_ONLY:
+        default:
+            return false;
+        }
     }
 
     /**
@@ -1329,27 +1375,7 @@ public class Component
             {
                 // The pair recovered (or succeeded for the first time).
                 keepAlivePairsFailedSince.remove(pair);
-
-                if (keepAliveStrategy == KeepAliveStrategy.ALL_SUCCEEDED)
-                {
-                    addToKeepAlive = true;
-                }
-                else if (keepAliveStrategy == KeepAliveStrategy.SELECTED_AND_TCP)
-                {
-                    Transport transport
-                        = pair.getLocalCandidate().getTransport();
-                    addToKeepAlive = transport == Transport.TCP
-                        || transport == Transport.SSLTCP;
-
-                    // Pairs with a remote TCP port 9 cannot be checked.
-                    // Instead, the corresponding pair with the peer reflexive
-                    // candidate needs to be checked. However, we observe
-                    // such pairs transitioning into the SUCCEEDED state.
-                    // Ignore them.
-                    addToKeepAlive
-                        &= pair.getRemoteCandidate()
-                                .getTransportAddress().getPort() != 9;
-                }
+                addToKeepAlive = wantsKeepAlive(pair);
             }
         }
 

--- a/src/main/java/org/ice4j/ice/Component.java
+++ b/src/main/java/org/ice4j/ice/Component.java
@@ -20,6 +20,7 @@ package org.ice4j.ice;
 import java.beans.*;
 import java.io.*;
 import java.net.*;
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 
@@ -155,6 +156,23 @@ public class Component
      * that compound operations such as check-then-add are atomic), while iteration is lock-free.
      */
     private final Set<CandidatePair> keepAlivePairs = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    /**
+     * The time at which each keep-alive pair currently in the FAILED state first failed (since it was last
+     * SUCCEEDED). Used to remove pairs which have been failed for too long, see {@link #failedKeepAlivePairTimeout}.
+     */
+    private final Map<CandidatePair, Instant> keepAlivePairsFailedSince = new ConcurrentHashMap<>();
+
+    /**
+     * How long a keep-alive pair (other than the selected pair) may stay FAILED before it is removed from
+     * {@link #keepAlivePairs}. Zero or negative disables the removal.
+     */
+    private final Duration failedKeepAlivePairTimeout = AgentConfig.config.getKeepAliveFailedPairTimeout();
+
+    /**
+     * The clock used to measure how long keep-alive pairs have been failed. Replaceable for tests.
+     */
+    private Clock clock = Clock.systemUTC();
 
     /**
      * External callback for the push API. Called with every packet received via {@link #handleBuffer(Buffer)}.
@@ -900,6 +918,7 @@ public class Component
 
         getParentStream().removePairStateChangeListener(this);
         keepAlivePairs.clear();
+        keepAlivePairsFailedSince.clear();
         if (componentSocket != null)
         {
             componentSocket.close();
@@ -1070,8 +1089,65 @@ public class Component
                 }
             }
             keepAlivePairs.add(pair);
+            if (pair.getState() == CandidatePairState.FAILED)
+            {
+                // A pair which is added while already failed gets the full timeout from now.
+                keepAlivePairsFailedSince.put(pair, clock.instant());
+            }
+            else
+            {
+                keepAlivePairsFailedSince.remove(pair);
+            }
             return true;
         }
+    }
+
+    /**
+     * Handles a keep-alive pair transitioning to (or staying in) the FAILED state: removes it from the set of
+     * keep-alive pairs if it has been failed for longer than {@link #failedKeepAlivePairTimeout}. The selected pair
+     * is never removed. Keep-alive checks continue to be sent to a failed pair until it is removed, so it can recover
+     * (which resets the timer).
+     */
+    private void maybeRemoveFailedKeepAlivePair(CandidatePair pair)
+    {
+        synchronized (keepAlivePairs)
+        {
+            if (!keepAlivePairs.contains(pair) || pair.equals(selectedPair))
+            {
+                return;
+            }
+
+            Instant now = clock.instant();
+            Instant failedSince = keepAlivePairsFailedSince.putIfAbsent(pair, now);
+            if (failedSince == null)
+            {
+                // This is the first failure, start the timer.
+                return;
+            }
+
+            if (failedKeepAlivePairTimeout.isZero() || failedKeepAlivePairTimeout.isNegative())
+            {
+                // Removal is disabled. We still track the failure above.
+                return;
+            }
+
+            Duration failedFor = Duration.between(failedSince, now);
+            if (failedFor.compareTo(failedKeepAlivePairTimeout) >= 0)
+            {
+                keepAlivePairs.remove(pair);
+                keepAlivePairsFailedSince.remove(pair);
+                logger.info("Removing keep-alive pair " + pair.toRedactedShortString()
+                        + ", failed for " + failedFor.toMillis() + " ms.");
+            }
+        }
+    }
+
+    /**
+     * Sets the clock used to measure how long keep-alive pairs have been failed. For tests.
+     */
+    void setClock(Clock clock)
+    {
+        this.clock = Objects.requireNonNull(clock);
     }
 
     /**
@@ -1229,8 +1305,15 @@ public class Component
             CandidatePairState newState
                 = (CandidatePairState) event.getNewValue();
 
-            if (CandidatePairState.SUCCEEDED.equals(newState))
+            if (CandidatePairState.FAILED.equals(newState))
             {
+                maybeRemoveFailedKeepAlivePair(pair);
+            }
+            else if (CandidatePairState.SUCCEEDED.equals(newState))
+            {
+                // The pair recovered (or succeeded for the first time).
+                keepAlivePairsFailedSince.remove(pair);
+
                 if (keepAliveStrategy == KeepAliveStrategy.ALL_SUCCEEDED)
                 {
                     addToKeepAlive = true;

--- a/src/main/java/org/ice4j/ice/ConnectivityCheckClient.java
+++ b/src/main/java/org/ice4j/ice/ConnectivityCheckClient.java
@@ -884,7 +884,16 @@ class ConnectivityCheckClient
         CandidatePair pair
             = (CandidatePair) ev.getTransactionID() .getApplicationData();
 
-        logger.info("timeout for pair: " + pair.toRedactedShortString() + ", failing.");
+        if (pair.getState() == CandidatePairState.FAILED)
+        {
+            // Keep-alive checks are sent to pairs that have already failed (so they can recover). Don't log at
+            // INFO every time such a check times out again.
+            logger.debug(() -> "timeout for pair: " + pair.toRedactedShortString() + ", already failed.");
+        }
+        else
+        {
+            logger.info("timeout for pair: " + pair.toRedactedShortString() + ", failing.");
+        }
         pair.setStateFailed();
         updateCheckListAndTimerStates(pair);
     }

--- a/src/main/kotlin/org/ice4j/ice/AgentConfig.kt
+++ b/src/main/kotlin/org/ice4j/ice/AgentConfig.kt
@@ -86,6 +86,14 @@ class AgentConfig {
         "ice4j.send-to-last-received-from-address".from(configSource)
     }
 
+    /**
+     * How long a keep-alive pair (other than the selected pair) may stay in the FAILED state before it is removed
+     * from the set of keep-alive pairs. Zero or negative disables the removal.
+     */
+    val keepAliveFailedPairTimeout: Duration by config {
+        "ice4j.keep-alive.failed-pair-timeout".from(configSource)
+    }
+
     companion object {
         @JvmField
         val config = AgentConfig()

--- a/src/main/kotlin/org/ice4j/ice/AgentConfig.kt
+++ b/src/main/kotlin/org/ice4j/ice/AgentConfig.kt
@@ -94,6 +94,13 @@ class AgentConfig {
         "ice4j.keep-alive.failed-pair-timeout".from(configSource)
     }
 
+    /**
+     * The maximum number of pairs to keep alive per component. Zero or negative means no limit.
+     */
+    val maxKeepAlivePairs: Int by config {
+        "ice4j.keep-alive.max-pairs".from(configSource)
+    }
+
     companion object {
         @JvmField
         val config = AgentConfig()

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -24,6 +24,13 @@ ice4j {
   // Whether remote IP addresses should be redacted in log messages
   redact-remote-addresses = false
 
+  keep-alive {
+    // A keep-alive pair other than the selected pair which stays in the FAILED state (i.e. its keep-alive checks
+    // time out) for this long is removed from the set of keep-alive pairs, and no more checks are sent to it. Set to
+    // 0 to never remove failed pairs.
+    failed-pair-timeout = 30 seconds
+  }
+
   consent-freshness {
     // How often a STUN Binding request used for consent freshness check will be sent.
     interval = 15 seconds

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -29,6 +29,10 @@ ice4j {
     // time out) for this long is removed from the set of keep-alive pairs, and no more checks are sent to it. Set to
     // 0 to never remove failed pairs.
     failed-pair-timeout = 30 seconds
+    // The maximum number of pairs to keep alive per component (this is only relevant with the ALL_SUCCEEDED and
+    // SELECTED_AND_TCP keep-alive strategies). When the limit is reached, failed pairs and then pairs with the lowest
+    // priority are evicted (the selected pair is never evicted). Set to 0 for no limit.
+    max-pairs = 10
   }
 
   consent-freshness {

--- a/src/test/java/org/ice4j/ice/ComponentKeepAliveTest.java
+++ b/src/test/java/org/ice4j/ice/ComponentKeepAliveTest.java
@@ -304,4 +304,65 @@ public class ComponentKeepAliveTest
         pair.setStateSucceeded();
         assertEquals(Collections.singleton(pair), keepAlivePairs());
     }
+
+    @Test
+    public void testWantsKeepAlive()
+        throws IOException
+    {
+        setUp(KeepAliveStrategy.ALL_SUCCEEDED);
+        assertTrue(component.wantsKeepAlive(createPair(host, createRemoteCandidate(1000))));
+        tearDown();
+
+        setUp(KeepAliveStrategy.SELECTED_ONLY);
+        assertFalse(component.wantsKeepAlive(createPair(host, createRemoteCandidate(1000))));
+        tearDown();
+
+        setUp(KeepAliveStrategy.SELECTED_AND_TCP);
+        assertFalse(component.wantsKeepAlive(createPair(host, createRemoteCandidate(1000))), "UDP pair");
+    }
+
+    /**
+     * A pair which is not SUCCEEDED can be added explicitly (this is used to re-check a pair on which the remote side
+     * sends a check after ICE has terminated). It is subject to the same removal once it has been failed for too
+     * long, and equivalent pairs are still deduplicated.
+     */
+    @Test
+    public void testExplicitlyAddedFailedPair()
+        throws IOException
+    {
+        setUp(KeepAliveStrategy.ALL_SUCCEEDED);
+        CandidatePair selected = createPair(host, createRemoteCandidate(1000));
+        selected.setStateSucceeded();
+        component.setSelectedPair(selected);
+
+        RemoteCandidate remote = createRemoteCandidate(2000);
+        CandidatePair failed = createPair(host, remote);
+        failed.setStateFailed();
+        assertFalse(keepAlivePairs().contains(failed));
+
+        assertTrue(component.addKeepAlivePair(failed));
+        assertFalse(component.addKeepAlivePair(failed), "Already present");
+        assertFalse(component.addKeepAlivePair(createPair(mapped, remote)), "Equivalent pair present");
+        assertEquals(new HashSet<>(Arrays.asList(selected, failed)), keepAlivePairs());
+
+        // If the check we send fails, the pair is removed again after the timeout.
+        failed.setStateFailed();
+        advance(Duration.ofSeconds(15));
+        failed.setStateFailed();
+        advance(Duration.ofSeconds(15));
+        failed.setStateFailed();
+        assertEquals(Collections.singleton(selected), keepAlivePairs());
+
+        // It is not added again for re-checking until the timeout has passed since it was removed.
+        assertFalse(component.addKeepAlivePair(failed), "Recently removed");
+        advance(Duration.ofSeconds(29));
+        assertFalse(component.addKeepAlivePair(failed), "Recently removed");
+        advance(Duration.ofSeconds(1));
+
+        // If the check succeeds, it stays.
+        assertTrue(component.addKeepAlivePair(failed));
+        failed.setStateSucceeded();
+        advance(Duration.ofMinutes(5));
+        assertEquals(new HashSet<>(Arrays.asList(selected, failed)), keepAlivePairs());
+    }
 }

--- a/src/test/java/org/ice4j/ice/ComponentKeepAliveTest.java
+++ b/src/test/java/org/ice4j/ice/ComponentKeepAliveTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.*;
 import java.net.*;
+import java.time.*;
 import java.util.*;
 
 import org.ice4j.*;
@@ -46,6 +47,9 @@ public class ComponentKeepAliveTest
 
     private int nextRemotePort = 20000;
 
+    /** The current time as seen by the component. */
+    private Instant now = Instant.parse("2026-01-01T00:00:00Z");
+
     private void setUp(KeepAliveStrategy strategy)
         throws IOException
     {
@@ -57,6 +61,7 @@ public class ComponentKeepAliveTest
         // Create the component directly on the stream rather than via Agent.createComponent(), which would harvest
         // candidates on the real network interfaces.
         component = stream.createComponent(strategy, false);
+        component.setClock(Clock.fixed(now, ZoneOffset.UTC));
 
         host = new HostCandidate(new IceUdpSocketWrapper(localSocket), component);
         component.addLocalCandidate(host);
@@ -95,6 +100,12 @@ public class ComponentKeepAliveTest
     private CandidatePair createPair(LocalCandidate local, RemoteCandidate remote)
     {
         return agent.createCandidatePair(local, remote);
+    }
+
+    private void advance(Duration duration)
+    {
+        now = now.plus(duration);
+        component.setClock(Clock.fixed(now, ZoneOffset.UTC));
     }
 
     private Set<CandidatePair> keepAlivePairs()
@@ -177,5 +188,98 @@ public class ComponentKeepAliveTest
 
         component.setSelectedPair(pairA);
         assertEquals(Collections.singleton(pairA), keepAlivePairs());
+    }
+
+    /**
+     * A non-selected pair which stays failed for the configured timeout (30 seconds by default) is removed. Failures
+     * are reported on every keep-alive interval while the pair is failed.
+     */
+    @Test
+    public void testFailedPairIsRemovedAfterTimeout()
+        throws IOException
+    {
+        setUp(KeepAliveStrategy.ALL_SUCCEEDED);
+        CandidatePair selected = createPair(host, createRemoteCandidate(1000));
+        CandidatePair backup = createPair(host, createRemoteCandidate(2000));
+        selected.setStateSucceeded();
+        backup.setStateSucceeded();
+        component.setSelectedPair(selected);
+        assertEquals(new HashSet<>(Arrays.asList(selected, backup)), keepAlivePairs());
+
+        backup.setStateFailed();
+        assertTrue(keepAlivePairs().contains(backup), "Not removed on first failure");
+
+        advance(Duration.ofSeconds(15));
+        backup.setStateFailed();
+        assertTrue(keepAlivePairs().contains(backup), "Not removed before the timeout");
+
+        advance(Duration.ofSeconds(15));
+        backup.setStateFailed();
+        assertEquals(Collections.singleton(selected), keepAlivePairs(), "Removed once failed for the timeout");
+    }
+
+    @Test
+    public void testSelectedPairIsNeverRemoved()
+        throws IOException
+    {
+        setUp(KeepAliveStrategy.ALL_SUCCEEDED);
+        CandidatePair selected = createPair(host, createRemoteCandidate(1000));
+        selected.setStateSucceeded();
+        component.setSelectedPair(selected);
+
+        for (int i = 0; i < 10; i++)
+        {
+            selected.setStateFailed();
+            advance(Duration.ofSeconds(15));
+        }
+        assertEquals(Collections.singleton(selected), keepAlivePairs());
+    }
+
+    /**
+     * A pair which recovers (succeeds again) before the timeout is kept, and the timer restarts on its next failure.
+     */
+    @Test
+    public void testRecoveredPairIsKept()
+        throws IOException
+    {
+        setUp(KeepAliveStrategy.ALL_SUCCEEDED);
+        CandidatePair selected = createPair(host, createRemoteCandidate(1000));
+        CandidatePair backup = createPair(host, createRemoteCandidate(2000));
+        selected.setStateSucceeded();
+        backup.setStateSucceeded();
+        component.setSelectedPair(selected);
+
+        backup.setStateFailed();
+        advance(Duration.ofSeconds(15));
+        backup.setStateSucceeded();
+        advance(Duration.ofSeconds(15));
+
+        // 30 seconds since the first failure, but it recovered in between.
+        backup.setStateFailed();
+        assertTrue(keepAlivePairs().contains(backup));
+        advance(Duration.ofSeconds(15));
+        backup.setStateFailed();
+        assertTrue(keepAlivePairs().contains(backup));
+        advance(Duration.ofSeconds(15));
+        backup.setStateFailed();
+        assertFalse(keepAlivePairs().contains(backup));
+    }
+
+    /**
+     * A failed pair which is not a keep-alive pair (it never succeeded) is not affected.
+     */
+    @Test
+    public void testFailedNonKeepAlivePairIsIgnored()
+        throws IOException
+    {
+        setUp(KeepAliveStrategy.ALL_SUCCEEDED);
+        CandidatePair pair = createPair(host, createRemoteCandidate(1000));
+        pair.setStateFailed();
+        advance(Duration.ofMinutes(5));
+        pair.setStateFailed();
+        assertTrue(keepAlivePairs().isEmpty());
+
+        pair.setStateSucceeded();
+        assertEquals(Collections.singleton(pair), keepAlivePairs());
     }
 }

--- a/src/test/java/org/ice4j/ice/ComponentKeepAliveTest.java
+++ b/src/test/java/org/ice4j/ice/ComponentKeepAliveTest.java
@@ -365,4 +365,113 @@ public class ComponentKeepAliveTest
         advance(Duration.ofMinutes(5));
         assertEquals(new HashSet<>(Arrays.asList(selected, failed)), keepAlivePairs());
     }
+
+    /** Creates {@code count} pairs with distinct remote addresses and increasing priorities, and succeeds them. */
+    private List<CandidatePair> fillKeepAlivePairs(int count)
+    {
+        List<CandidatePair> pairs = new ArrayList<>();
+        for (int i = 1; i <= count; i++)
+        {
+            CandidatePair pair = createPair(host, createRemoteCandidate(1000L * i));
+            pair.setStateSucceeded();
+            pairs.add(pair);
+        }
+        assertEquals(new HashSet<>(pairs), keepAlivePairs());
+        return pairs;
+    }
+
+    /**
+     * At most ice4j.keep-alive.max-pairs (10 by default) pairs are kept alive. When the set is full, a new pair with
+     * a higher priority than the lowest-priority pair replaces it, and a new pair with a lower priority is not added.
+     */
+    @Test
+    public void testMaxPairsEvictsLowestPriority()
+        throws IOException
+    {
+        setUp(KeepAliveStrategy.ALL_SUCCEEDED);
+        List<CandidatePair> pairs = fillKeepAlivePairs(10);
+        assertTrue(pairs.get(0).getPriority() < pairs.get(9).getPriority());
+
+        CandidatePair low = createPair(host, createRemoteCandidate(500));
+        low.setStateSucceeded();
+        assertFalse(keepAlivePairs().contains(low), "Lower priority than all existing pairs, not added");
+        assertEquals(10, keepAlivePairs().size());
+
+        CandidatePair high = createPair(host, createRemoteCandidate(20000));
+        high.setStateSucceeded();
+        Set<CandidatePair> expected = new HashSet<>(pairs.subList(1, 10));
+        expected.add(high);
+        assertEquals(expected, keepAlivePairs(), "Lowest priority pair evicted");
+    }
+
+    /**
+     * A failed pair is evicted before any succeeded pair, regardless of priority.
+     */
+    @Test
+    public void testMaxPairsEvictsFailedFirst()
+        throws IOException
+    {
+        setUp(KeepAliveStrategy.ALL_SUCCEEDED);
+        List<CandidatePair> pairs = fillKeepAlivePairs(10);
+        CandidatePair failed = pairs.get(5);
+        failed.setStateFailed();
+        assertTrue(keepAlivePairs().contains(failed), "Still present, not failed for long enough");
+
+        CandidatePair low = createPair(host, createRemoteCandidate(500));
+        low.setStateSucceeded();
+        Set<CandidatePair> expected = new HashSet<>(pairs);
+        expected.remove(failed);
+        expected.add(low);
+        assertEquals(expected, keepAlivePairs());
+    }
+
+    /**
+     * The selected pair is always kept alive, even if the set is full and its priority is the lowest.
+     */
+    @Test
+    public void testSelectedPairAlwaysAdded()
+        throws IOException
+    {
+        setUp(KeepAliveStrategy.ALL_SUCCEEDED);
+        List<CandidatePair> pairs = fillKeepAlivePairs(10);
+
+        CandidatePair selected = createPair(host, createRemoteCandidate(50));
+        selected.setStateSucceeded();
+        assertFalse(keepAlivePairs().contains(selected));
+
+        component.setSelectedPair(selected);
+        Set<CandidatePair> expected = new HashSet<>(pairs.subList(1, 10));
+        expected.add(selected);
+        assertEquals(expected, keepAlivePairs());
+
+        // And it is not evicted by a higher priority pair.
+        CandidatePair high = createPair(host, createRemoteCandidate(20000));
+        high.setStateSucceeded();
+        assertTrue(keepAlivePairs().contains(selected));
+        assertTrue(keepAlivePairs().contains(high));
+        assertEquals(10, keepAlivePairs().size());
+    }
+
+    /**
+     * A pair which has not succeeded (added for re-checking) may only displace a failed pair, never a succeeded one,
+     * regardless of its priority.
+     */
+    @Test
+    public void testRecheckedPairDoesNotEvictSucceededPair()
+        throws IOException
+    {
+        setUp(KeepAliveStrategy.ALL_SUCCEEDED);
+        List<CandidatePair> pairs = fillKeepAlivePairs(10);
+
+        CandidatePair high = createPair(host, createRemoteCandidate(20000));
+        assertFalse(component.addKeepAlivePair(high), "Set full of succeeded pairs");
+        assertEquals(new HashSet<>(pairs), keepAlivePairs());
+
+        pairs.get(3).setStateFailed();
+        assertTrue(component.addKeepAlivePair(high), "Failed pair can be displaced");
+        Set<CandidatePair> expected = new HashSet<>(pairs);
+        expected.remove(pairs.get(3));
+        expected.add(high);
+        assertEquals(expected, keepAlivePairs());
+    }
 }

--- a/src/test/java/org/ice4j/ice/ComponentKeepAliveTest.java
+++ b/src/test/java/org/ice4j/ice/ComponentKeepAliveTest.java
@@ -190,6 +190,28 @@ public class ComponentKeepAliveTest
         assertEquals(Collections.singleton(pairA), keepAlivePairs());
     }
 
+    @Test
+    public void testHasKeepAlivePairForRemoteAddress()
+        throws IOException
+    {
+        setUp(KeepAliveStrategy.SELECTED_ONLY);
+        RemoteCandidate remoteA = createRemoteCandidate(1000);
+        RemoteCandidate remoteB = createRemoteCandidate(2000);
+        CandidatePair pairA = createPair(host, remoteA);
+        CandidatePair pairB = createPair(host, remoteB);
+        pairA.setStateSucceeded();
+        pairB.setStateSucceeded();
+        assertFalse(component.hasKeepAlivePairForRemoteAddress(remoteA.getTransportAddress()));
+
+        component.setSelectedPair(pairA);
+        assertTrue(component.hasKeepAlivePairForRemoteAddress(remoteA.getTransportAddress()));
+        assertFalse(component.hasKeepAlivePairForRemoteAddress(remoteB.getTransportAddress()));
+
+        // The equivalent pair with the mapped candidate has the same remote address.
+        createPair(mapped, remoteA).setStateSucceeded();
+        assertTrue(component.hasKeepAlivePairForRemoteAddress(remoteA.getTransportAddress()));
+    }
+
     /**
      * A non-selected pair which stays failed for the configured timeout (30 seconds by default) is removed. Failures
      * are reported on every keep-alive interval while the pair is failed.

--- a/src/test/java/org/ice4j/ice/ComponentKeepAliveTest.java
+++ b/src/test/java/org/ice4j/ice/ComponentKeepAliveTest.java
@@ -1,0 +1,181 @@
+/*
+ * ice4j, the OpenSource Java Solution for NAT and Firewall Traversal.
+ *
+ * Copyright @ 2026 8x8, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ice4j.ice;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.*;
+import java.net.*;
+import java.util.*;
+
+import org.ice4j.*;
+import org.ice4j.socket.*;
+import org.junit.jupiter.api.*;
+
+/**
+ * Tests the maintenance of the set of keep-alive pairs of a {@link Component}.
+ */
+public class ComponentKeepAliveTest
+{
+    private static final InetAddress LOOPBACK = InetAddress.getLoopbackAddress();
+
+    private Agent agent;
+    private IceMediaStream stream;
+    private Component component;
+    private DatagramSocket localSocket;
+
+    /** A host candidate. */
+    private HostCandidate host;
+    /** A mapped candidate whose base is {@link #host}, i.e. it uses the same socket. */
+    private ServerReflexiveCandidate mapped;
+
+    private int nextRemotePort = 20000;
+
+    private void setUp(KeepAliveStrategy strategy)
+        throws IOException
+    {
+        localSocket = new DatagramSocket(0, LOOPBACK);
+
+        agent = new Agent("test", null);
+        agent.setControlling(true);
+        stream = agent.createMediaStream("stream");
+        // Create the component directly on the stream rather than via Agent.createComponent(), which would harvest
+        // candidates on the real network interfaces.
+        component = stream.createComponent(strategy, false);
+
+        host = new HostCandidate(new IceUdpSocketWrapper(localSocket), component);
+        component.addLocalCandidate(host);
+        mapped = new ServerReflexiveCandidate(
+                new TransportAddress("198.51.100.1", localSocket.getLocalPort(), Transport.UDP),
+                host,
+                null,
+                CandidateExtendedType.STATICALLY_MAPPED_CANDIDATE);
+        component.addLocalCandidate(mapped);
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        if (agent != null)
+        {
+            agent.free();
+        }
+        if (localSocket != null)
+        {
+            localSocket.close();
+        }
+    }
+
+    private RemoteCandidate createRemoteCandidate(long priority)
+    {
+        return new RemoteCandidate(
+                new TransportAddress("203.0.113.1", nextRemotePort++, Transport.UDP),
+                component,
+                CandidateType.PEER_REFLEXIVE_CANDIDATE,
+                "foundation" + priority,
+                priority,
+                null);
+    }
+
+    private CandidatePair createPair(LocalCandidate local, RemoteCandidate remote)
+    {
+        return agent.createCandidatePair(local, remote);
+    }
+
+    private Set<CandidatePair> keepAlivePairs()
+    {
+        return new HashSet<>(component.getKeepAlivePairs());
+    }
+
+    @Test
+    public void testAllSucceededAddsSucceededPairs()
+        throws IOException
+    {
+        setUp(KeepAliveStrategy.ALL_SUCCEEDED);
+        CandidatePair pairA = createPair(host, createRemoteCandidate(1000));
+        CandidatePair pairB = createPair(host, createRemoteCandidate(2000));
+
+        pairA.setStateSucceeded();
+        pairB.setStateSucceeded();
+
+        assertEquals(new HashSet<>(Arrays.asList(pairA, pairB)), keepAlivePairs());
+    }
+
+    /**
+     * The pair with the host candidate and the pair with the mapped candidate derived from it both use the same
+     * socket to reach the same remote address. Only one of them should be kept alive.
+     */
+    @Test
+    public void testEquivalentPairsAreDeduplicated()
+        throws IOException
+    {
+        setUp(KeepAliveStrategy.ALL_SUCCEEDED);
+        RemoteCandidate remote = createRemoteCandidate(1000);
+        CandidatePair hostPair = createPair(host, remote);
+        CandidatePair mappedPair = createPair(mapped, remote);
+
+        hostPair.setStateSucceeded();
+        mappedPair.setStateSucceeded();
+
+        assertEquals(Collections.singleton(hostPair), keepAlivePairs());
+
+        // Pairs to a different remote address are not equivalent.
+        CandidatePair otherPair = createPair(mapped, createRemoteCandidate(2000));
+        otherPair.setStateSucceeded();
+        assertEquals(new HashSet<>(Arrays.asList(hostPair, otherPair)), keepAlivePairs());
+    }
+
+    /**
+     * When a pair is selected it replaces any equivalent pair already in the set.
+     */
+    @Test
+    public void testSelectedPairReplacesEquivalentPair()
+        throws IOException
+    {
+        setUp(KeepAliveStrategy.ALL_SUCCEEDED);
+        RemoteCandidate remote = createRemoteCandidate(1000);
+        CandidatePair hostPair = createPair(host, remote);
+        CandidatePair mappedPair = createPair(mapped, remote);
+        CandidatePair otherPair = createPair(host, createRemoteCandidate(2000));
+
+        hostPair.setStateSucceeded();
+        otherPair.setStateSucceeded();
+        assertEquals(new HashSet<>(Arrays.asList(hostPair, otherPair)), keepAlivePairs());
+
+        mappedPair.setStateSucceeded();
+        component.setSelectedPair(mappedPair);
+
+        assertEquals(new HashSet<>(Arrays.asList(mappedPair, otherPair)), keepAlivePairs());
+    }
+
+    @Test
+    public void testSelectedOnlyKeepsOnlySelectedPair()
+        throws IOException
+    {
+        setUp(KeepAliveStrategy.SELECTED_ONLY);
+        CandidatePair pairA = createPair(host, createRemoteCandidate(1000));
+        CandidatePair pairB = createPair(host, createRemoteCandidate(2000));
+
+        pairA.setStateSucceeded();
+        pairB.setStateSucceeded();
+        assertTrue(keepAlivePairs().isEmpty());
+
+        component.setSelectedPair(pairA);
+        assertEquals(Collections.singleton(pairA), keepAlivePairs());
+    }
+}

--- a/src/test/kotlin/org/ice4j/ice/AgentConfigTest.kt
+++ b/src/test/kotlin/org/ice4j/ice/AgentConfigTest.kt
@@ -32,6 +32,7 @@ class AgentConfigTest : ConfigTest() {
             config.maxCheckListSize shouldBe 100
             config.terminationDelay shouldBe 3.secs
             config.keepAliveFailedPairTimeout shouldBe 30.secs
+            config.maxKeepAlivePairs shouldBe 10
         }
         context("Setting via legacy config (system properties)") {
             withLegacyConfig(legacyConfig) {
@@ -52,6 +53,7 @@ class AgentConfigTest : ConfigTest() {
                 config.terminationDelay shouldBe 6.secs
                 config.maxCheckListSize shouldBe 6000
                 config.keepAliveFailedPairTimeout shouldBe 6.secs
+                config.maxKeepAlivePairs shouldBe 6
             }
         }
         context("Legacy config must take precedence") {
@@ -86,5 +88,6 @@ private val newConfig = """
     ice4j.ice.max-check-list-size = 6000
     ice4j.ice.termination-delay = 6 seconds
     ice4j.keep-alive.failed-pair-timeout = 6 seconds
+    ice4j.keep-alive.max-pairs = 6
     
 """.trimIndent()

--- a/src/test/kotlin/org/ice4j/ice/AgentConfigTest.kt
+++ b/src/test/kotlin/org/ice4j/ice/AgentConfigTest.kt
@@ -31,6 +31,7 @@ class AgentConfigTest : ConfigTest() {
             config.maxConsentFreshnessRetransmissions shouldBe 30
             config.maxCheckListSize shouldBe 100
             config.terminationDelay shouldBe 3.secs
+            config.keepAliveFailedPairTimeout shouldBe 30.secs
         }
         context("Setting via legacy config (system properties)") {
             withLegacyConfig(legacyConfig) {
@@ -50,6 +51,7 @@ class AgentConfigTest : ConfigTest() {
                 config.maxConsentFreshnessRetransmissions shouldBe 6000
                 config.terminationDelay shouldBe 6.secs
                 config.maxCheckListSize shouldBe 6000
+                config.keepAliveFailedPairTimeout shouldBe 6.secs
             }
         }
         context("Legacy config must take precedence") {
@@ -83,5 +85,6 @@ private val newConfig = """
     ice4j.consent-freshness.max-retransmissions = 6000 
     ice4j.ice.max-check-list-size = 6000
     ice4j.ice.termination-delay = 6 seconds
+    ice4j.keep-alive.failed-pair-timeout = 6 seconds
     
 """.trimIndent()


### PR DESCRIPTION
Follow-ups to #311, aimed at the `ALL_SUCCEEDED` keep-alive strategy, which is what our production deployments use and which we are considering making the default. Nothing ever removed a pair from the keep-alive set, each remote address was kept alive twice, and the set was unbounded. The commits are independent and meant to be reviewed one at a time.

## Commits

1. **Log keep-alive timeouts at INFO only on the transition to FAILED.** A pair that stays failed logged "timeout for pair ..., failing" every interval, forever.
2. **Deduplicate keep-alive pairs that use the same socket and remote address.** With single-port harvesting both the host pair and the mapped (srflx) pair to the same remote address succeed and were both kept alive. They share a socket and a destination, so the second is pure redundancy. The selected pair replaces its equivalent. Mutations of the set are now synchronized on the set (iteration stays lock-free).
3. **Remove keep-alive pairs which have been failed for too long.** New setting `ice4j.keep-alive.failed-pair-timeout` (30 s, matching libwebrtc's dead-connection timeout). The selected pair is never removed. Checks continue to be sent to a failed pair until it is removed, so a pair that recovers is kept.
4. **Don't schedule triggered checks once connectivity checks have stopped.** After termination, a check on a known non-SUCCEEDED pair was enqueued for the stopped pace maker and left the pair in WAITING forever, and we answered it regardless of strategy. Now one rule applies to every check after termination: respond only if a keep-alive pair has that remote address. For `SELECTED_ONLY` this is the existing behavior (#287, #304). For `SELECTED_AND_TCP` it now also covers the TCP pairs we keep alive (previously refused). For `ALL_SUCCEEDED` a peer checking a pair we don't keep alive gets an error and stops using it, instead of believing it works while we never send on it.
5. **Re-check a pair when the remote side checks it after termination.** If the peer checks a known pair that is not SUCCEEDED and the strategy would keep it alive, add it to the set and send a consent check. Success makes it usable again; failure removes it after the timeout, and it is not re-added for the same period, so a one-way path cannot make us probe continuously. Also, a keep-alive that cannot be sent at all now fails the pair. This mirrors libwebrtc, which destroys a dead connection and recreates it from the peer's next ping.
6. **Limit the number of keep-alive pairs per component.** New setting `ice4j.keep-alive.max-pairs` (10). When full, a failed pair is evicted first, otherwise the lowest-priority pair for a new pair with higher priority. A pair that has not succeeded (added for re-checking) can only displace a failed pair, so a peer cannot evict working pairs by advertising high-priority candidates. The selected pair is always kept.

## Notes on libwebrtc

libwebrtc has no cap on connections. It bounds cost by pinging one connection per fixed tick regardless of count, pings backups only every 25 s, stops pinging failed connections, and destroys connections that have received nothing for 30 s. ice4j's per-pair transactions make cost linear in the set size, hence the cap. The 30 s figure and the "destroy and recreate from the peer's ping" behavior follow libwebrtc.

## Behavior changes to note

- Commit 4 is the most visible: with `ALL_SUCCEEDED`, checks after termination on pairs outside the keep-alive set now get a 403 rather than a success response.
- Removal latency is observed at keep-alive intervals, so a dead pair is removed roughly 30 to 45 s after it dies.

## Tests

`ComponentKeepAliveTest` (15 tests) covers dedup, selected-pair replacement, removal after the timeout, non-removal of the selected pair, recovery resetting the timer, the re-add cooldown, the cap and its eviction order, and the strategy predicate. `AgentConfigTest` covers the two new settings. Each commit compiles on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
