### PR TITLE
Update to Kotlin 2.4.20 and current test tooling; require Java 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   # Java version to use for the release
-  RELEASE_JAVA_VERSION: 11
+  RELEASE_JAVA_VERSION: 17
 
 jobs:
   test:
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [ 11, 17, 21 ]
+        java: [ 17, 21 ]
 
     name: Java ${{ matrix.java }}
 

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
           </execution>
         </executions>
         <configuration>
-          <jvmTarget>11</jvmTarget>
+          <jvmTarget>17</jvmTarget>
           <args>
             <arg>-Xallow-result-return-type</arg>
           </args>
@@ -196,7 +196,7 @@
           </execution>
         </executions>
         <configuration>
-          <release>11</release>
+          <release>17</release>
           <compilerArgs>
             <arg>-Xlint:all</arg>
           </compilerArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -39,10 +39,11 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jicoco.version>1.1-127-gf49982f</jicoco.version>
-    <kotlin.version>1.9.10</kotlin.version>
-    <dokka.version>1.9.10</dokka.version>
-    <kotest.version>5.7.2</kotest.version>
-    <junit.version>5.10.0</junit.version>
+    <kotlin.version>2.4.20</kotlin.version>
+    <dokka.version>2.2.0</dokka.version>
+    <kotest.version>5.9.1</kotest.version>
+    <junit.version>5.14.4</junit.version>
+    <junit.platform.version>1.14.4</junit.platform.version>
   </properties>
 
   <dependencies>
@@ -66,12 +67,17 @@
       <artifactId>jicoco-config</artifactId>
       <version>${jicoco.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>${kotlin.version}</version>
+    </dependency>
 
     <!-- test -->
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
-      <version>1.10.0</version>
+      <version>${junit.platform.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -82,7 +88,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
@@ -269,6 +275,7 @@
           <includes>**/*</includes>
           <systemPropertyVariables>
             <java.util.logging.config.file>${project.build.testSourceDirectory}/../resources/logging.properties</java.util.logging.config.file>
+            <kotest.framework.classpath.scanning.autoscan.disable>true</kotest.framework.classpath.scanning.autoscan.disable>
           </systemPropertyVariables>
         </configuration>
       </plugin>


### PR DESCRIPTION
Two commits.

The first bumps Kotlin to 2.4.20, JUnit to 5.14.4, kotest to 5.9.1 and Dokka to 2.2.0, and declares kotlin-stdlib directly so the runtime stdlib always matches the compiler.

The second moves ice4j to Java 17 (jvmTarget and release 17, CI matrix 17 and 21, release JDK 17). jicoco has shipped Java 17 bytecode for some time, so this is needed before ice4j can pick up newer jicoco releases. The active consumers of ice4j (jitsi-videobridge, jigasi) already require Java 17.

This is one of a set of same-named kotlin-2.4 branches across jitsi-utils, jitsi-metaconfig, jicoco, jitsi-xmpp-extensions, ice4j, jicofo, jitsi-videobridge and jibri. Each PR only bumps the compiler and test/doc tooling; dependency versions between the jitsi repos are unchanged, so the PRs are independently mergeable. A library built with Kotlin 2.4 can only be consumed by Kotlin 2.3 or newer, so the compiler bumps should land everywhere before any repo picks up a 2.4-built release of another.