### PR TITLE
Run ktlint 1.8.0 directly via exec-maven-plugin and reformat

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,8 @@ indent_style = space
 max_line_length = 120
 
 [*.{kt,kts}]
+# Keep constructor parameters wrapped one per line, and kotest specs unindented.
+ktlint_standard_class-signature = disabled
 max_line_length = 120
 ktlint_code_style = intellij_idea
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <kotest.version>5.9.1</kotest.version>
     <junit.version>5.14.4</junit.version>
     <junit.platform.version>1.14.4</junit.platform.version>
+    <ktlint.version>1.8.0</ktlint.version>
   </properties>
 
   <dependencies>
@@ -224,24 +225,61 @@
           </execution>
         </executions>
       </plugin>
+      <!-- ktlint: check runs in the verify phase; auto-format with "mvn exec:exec@ktlint-format" -->
       <plugin>
-        <groupId>com.github.gantsign.maven</groupId>
-        <artifactId>ktlint-maven-plugin</artifactId>
-        <version>3.0.0</version>
-        <configuration>
-          <sourceRoots>
-            <sourceRoot>${project.basedir}/src/main/kotlin</sourceRoot>
-          </sourceRoots>
-          <testSourceRoots>
-            <testSourceRoot>${project.basedir}/src/test/kotlin</testSourceRoot>
-          </testSourceRoots>
-        </configuration>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.6.3</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.pinterest.ktlint</groupId>
+            <artifactId>ktlint-cli</artifactId>
+            <version>${ktlint.version}</version>
+            <classifier>all</classifier>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
-            <id>check</id>
+            <id>ktlint-check</id>
+            <phase>verify</phase>
             <goals>
-              <goal>check</goal>
+              <goal>exec</goal>
             </goals>
+            <configuration>
+              <executable>java</executable>
+              <includePluginDependencies>true</includePluginDependencies>
+              <arguments>
+                <argument>-classpath</argument>
+                <classpath>
+                  <dependency>com.pinterest.ktlint:ktlint-cli</dependency>
+                </classpath>
+                <argument>com.pinterest.ktlint.Main</argument>
+                <argument>--relative</argument>
+                <argument>src/main/kotlin/**/*.kt</argument>
+                <argument>src/test/kotlin/**/*.kt</argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>ktlint-format</id>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>java</executable>
+              <includePluginDependencies>true</includePluginDependencies>
+              <arguments>
+                <argument>-classpath</argument>
+                <classpath>
+                  <dependency>com.pinterest.ktlint:ktlint-cli</dependency>
+                </classpath>
+                <argument>com.pinterest.ktlint.Main</argument>
+                <argument>--format</argument>
+                <argument>--relative</argument>
+                <argument>src/main/kotlin/**/*.kt</argument>
+                <argument>src/test/kotlin/**/*.kt</argument>
+              </arguments>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/src/test/kotlin/org/ice4j/ice/harvest/StaticMappingCandidateHarvesterTest.kt
+++ b/src/test/kotlin/org/ice4j/ice/harvest/StaticMappingCandidateHarvesterTest.kt
@@ -46,7 +46,11 @@ class StaticMappingCandidateHarvesterTest : ShouldSpec() {
             every { logger } returns createLogger()
             every { componentID } returns Component.RTP
             every { localCandidates } returns listOf(
-                hostCandidate1, hostCandidate2, hostCandidate3, srflxCandidate1, srflxCandidate2
+                hostCandidate1,
+                hostCandidate2,
+                hostCandidate3,
+                srflxCandidate1,
+                srflxCandidate2
             )
             every { addLocalCandidate(any()) } returns true
         }


### PR DESCRIPTION
Replaces the third-party ktlint-maven-plugin, which tends to trail ktlint releases, with the integration ktlint documents itself: the ktlint CLI jar (1.8.0) as an exec-maven-plugin dependency, with the classpath restricted to that jar. The check still runs in the `verify` phase and fails the build on violations. Autoformat with `mvn exec:exec@ktlint-format` instead of `mvn ktlint:format`.

The `class-signature` rule added in ktlint 1.x is disabled in `.editorconfig`: it joins wrapped constructor parameter lists onto one line when they fit and re-indents every kotest spec, which we do not want. All other new rules are applied.

The second commit is the resulting reformat: 6 lines in 1 Kotlin files, almost entirely single-`return` function bodies becoming expression bodies and blank lines between multi-line `when` branches; plus KDoc comments that sat on non-declarations (ktlint cannot auto-correct these) become plain block comments. Behaviour-neutral.

This is one of a set of same-named `ktlint-1.8` branches across jitsi-utils, jitsi-metaconfig, jicoco, jitsi-xmpp-extensions, ice4j, jicofo, jitsi-videobridge and jibri. Each PR is independent; they only change how ktlint is run and apply its formatting.